### PR TITLE
Turn on more C++ compiler warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/dist)
 if(MSVC)
   add_compile_options(/W4 /WX)
 else()
-  add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 add_subdirectory(external/CLI11 ./external/CLI11 EXCLUDE_FROM_ALL)

--- a/samples/verona/lang.cc
+++ b/samples/verona/lang.cc
@@ -238,7 +238,7 @@ namespace verona
         },
 
       // Default initializers.
-      (T(Default) << End) >> ([](Match& _) -> Node { return DontCare; }),
+      (T(Default) << End) >> ([](Match&) -> Node { return DontCare; }),
       (T(Default) << (T(Group)[rhs]) * End) >>
         [](Match& _) { return Seq << *_[rhs]; },
       (T(Default) << (T(Group)++[rhs]) * End) >>
@@ -262,7 +262,7 @@ namespace verona
         },
 
       // Allow `ref` to be used as a type name.
-      TypeStruct * T(Ref) >> [](Match& _) { return Ident ^ ref; },
+      TypeStruct * T(Ref) >> [](Match&) { return Ident ^ ref; },
 
       TypeStruct *
           (T(Use) / T(Let) / T(Var) / T(Equals) / T(Class) / T(FatArrow) /
@@ -285,7 +285,7 @@ namespace verona
       In(Expr) * T(List)[List] >> [](Match& _) { return Tuple << *_[List]; },
 
       // Empty parens are an empty Tuple.
-      In(Expr) * (T(Paren) << End) >> ([](Match& _) -> Node { return Tuple; }),
+      In(Expr) * (T(Paren) << End) >> ([](Match&) -> Node { return Tuple; }),
 
       // Parens with one element are an Expr. Put the group, list, or equals
       // into the expr, where it will become an expr, tuple, or assign.
@@ -401,7 +401,7 @@ namespace verona
         },
 
       // Remove empty groups.
-      T(Group) << End >> ([](Match& _) -> Node { return {}; }),
+      T(Group) << End >> ([](Match&) -> Node { return {}; }),
       T(Group)[Group] >> [](Match& _) { return err(_[Group], "syntax error"); },
     };
   }
@@ -506,14 +506,14 @@ namespace verona
       // Tuples of arity 1 are scalar types, tuples of arity 0 are the unit
       // type.
       T(TypeTuple) << (TypeElem[op] * End) >> [](Match& _) { return _(op); },
-      T(TypeTuple) << End >> ([](Match& _) -> Node { return TypeUnit; }),
+      T(TypeTuple) << End >> ([](Match&) -> Node { return TypeUnit; }),
 
       // Flatten Type nodes. The top level Type node won't go away.
       TypeStruct * T(Type) << (TypeElem[op] * End) >>
         [](Match& _) { return _(op); },
 
       // Empty types are the unit type.
-      T(Type)[Type] << End >> [](Match& _) { return Type << TypeUnit; },
+      T(Type)[Type] << End >> [](Match&) { return Type << TypeUnit; },
 
       In(TypeThrow) * T(TypeThrow)[lhs] >>
         [](Match& _) { return err(_[lhs], "can't throw a throw type"); },

--- a/samples/verona/parse.cc
+++ b/samples/verona/parse.cc
@@ -15,9 +15,9 @@ namespace verona
     indent->push_back(restart);
 
     p.prefile(
-      [](auto& p, auto& path) { return path.extension() == ".verona"; });
+      [](auto&, auto& path) { return path.extension() == ".verona"; });
 
-    p.predir([](auto& p, auto& path) {
+    p.predir([](auto&, auto& path) {
       static auto re = std::regex(
         ".*/[_[:alpha:]][_[:alnum:]]*$", std::regex_constants::optimize);
       return std::regex_match(path.string(), re);
@@ -29,7 +29,7 @@ namespace verona
         ast->push_back(p.sub_parse(stdlib));
     });
 
-    p.postfile([indent, depth](auto& p, auto& path, auto ast) {
+    p.postfile([indent, depth](auto&, auto&, auto) {
       *depth = 0;
       indent->clear();
       indent->push_back(restart);
@@ -76,7 +76,7 @@ namespace verona
           },
 
         // Whitespace between tokens.
-        "[[:blank:]]+" >> [](auto& m) {},
+        "[[:blank:]]+" >> [](auto&) {},
 
         // Terminator.
         ";" >> [](auto& m) { m.term(terminators); },
@@ -168,7 +168,7 @@ namespace verona
         "'[^']*'" >> [](auto& m) { m.add(Char); },
 
         // Line comment.
-        "//[^\n]*" >> [](auto& m) {},
+        "//[^\n]*" >> [](auto&) {},
 
         // Nested comment.
         "/\\*" >>
@@ -217,7 +217,7 @@ namespace verona
 
     p("comment",
       {
-        "(?:[^\\*]|\\*(?!/))*/\\*" >> [depth](auto& m) { ++(*depth); },
+        "(?:[^\\*]|\\*(?!/))*/\\*" >> [depth](auto&) { ++(*depth); },
         "(?:[^/]|/(?!\\*))*\\*/" >>
           [depth](auto& m) {
             if (--(*depth) == 0)


### PR DESCRIPTION
This removes the remaining unused parameters and both turns off `-Wno-unused-parameter` and turns on `-Wpedantic`.
