### PR TITLE
Declarative symbol table generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build*/
 **/dump/*
 .*.swp
 compile_commands.json
+notes/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,9 @@ else()
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  add_compile_options(-Wmismatched-tags -fstandalone-debug)
+endif()
+
 add_subdirectory(external/CLI11 ./external/CLI11 EXCLUDE_FROM_ALL)
 add_subdirectory(samples/verona)

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ int main(int argc, char** argv)
 
 ## Building the Samples
 
-Here's an example of how to build the `verona` sample and run the self-tests:
+Here's an example of how to build the `verona` sample and run the self-tests. Other build systems and compilers may work as well.
 
 ```sh
 git clone --recursive https://github.com/microsoft/trieste
 cd trieste
 mkdir build
 cd build
-cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-12
+cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++-14
 ninja install
 ./dist/verona/verona test
 ```

--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -21,7 +21,7 @@ namespace verona
   inline constexpr auto Ellipsis = TokenDef("ellipsis");
   inline constexpr auto Colon = TokenDef("colon");
   inline constexpr auto DoubleColon = TokenDef("doublecolon");
-  inline constexpr auto FatArrow = TokenDef("fatarrow");
+  inline constexpr auto Arrow = TokenDef("arrow");
   inline constexpr auto Bool = TokenDef("bool", flag::print);
   inline constexpr auto Hex = TokenDef("hex", flag::print);
   inline constexpr auto Bin = TokenDef("bin", flag::print);
@@ -35,12 +35,15 @@ namespace verona
   inline constexpr auto Ident = TokenDef("ident", flag::print);
 
   // Parsing keywords.
-  inline constexpr auto Class = TokenDef("class", flag::symtab);
-  inline constexpr auto TypeAlias = TokenDef("typealias", flag::symtab);
+  inline constexpr auto Class = TokenDef(
+    "class", flag::symtab | flag::lookup | flag::lookdown | flag::shadowing);
+  inline constexpr auto TypeAlias = TokenDef(
+    "typealias",
+    flag::symtab | flag::lookup | flag::lookdown | flag::shadowing);
   inline constexpr auto Use = TokenDef("use");
   inline constexpr auto Package = TokenDef("package");
-  inline constexpr auto Var = TokenDef("var");
-  inline constexpr auto Let = TokenDef("let");
+  inline constexpr auto Var = TokenDef("var", flag::lookup | flag::shadowing);
+  inline constexpr auto Let = TokenDef("let", flag::lookup | flag::shadowing);
   inline constexpr auto Ref = TokenDef("ref");
   inline constexpr auto Throw = TokenDef("throw");
   inline constexpr auto Iso = TokenDef("iso");
@@ -51,16 +54,19 @@ namespace verona
   inline constexpr auto TypeTrait = TokenDef("typetrait", flag::symtab);
   inline constexpr auto ClassBody = TokenDef("classbody");
   inline constexpr auto FieldLet =
-    TokenDef("fieldlet", flag::symtab | flag::defbeforeuse);
+    TokenDef("fieldlet", flag::symtab | flag::defbeforeuse | flag::lookdown);
   inline constexpr auto FieldVar =
-    TokenDef("fieldvar", flag::symtab | flag::defbeforeuse);
-  inline constexpr auto Function =
-    TokenDef("function", flag::symtab | flag::defbeforeuse | flag::multidef);
+    TokenDef("fieldvar", flag::symtab | flag::defbeforeuse | flag::lookdown);
+  inline constexpr auto Function = TokenDef(
+    "function",
+    flag::symtab | flag::defbeforeuse | flag::lookup | flag::lookdown);
   inline constexpr auto TypeParams = TokenDef("typeparams");
-  inline constexpr auto TypeParam = TokenDef("typeparam");
+  inline constexpr auto TypeParam =
+    TokenDef("typeparam", flag::lookup | flag::lookdown | flag::shadowing);
   inline constexpr auto Params = TokenDef("params");
-  inline constexpr auto Param =
-    TokenDef("param", flag::symtab | flag::defbeforeuse);
+  inline constexpr auto Param = TokenDef(
+    "param",
+    flag::symtab | flag::defbeforeuse | flag::lookup | flag::shadowing);
   inline constexpr auto FuncBody = TokenDef("funcbody");
 
   // Type structure.
@@ -92,16 +98,15 @@ namespace verona
   inline constexpr auto Selector = TokenDef("selector");
   inline constexpr auto Call = TokenDef("call");
   inline constexpr auto Args = TokenDef("args");
-  inline constexpr auto Include = TokenDef("include");
   inline constexpr auto TupleLHS = TokenDef("tuple-lhs");
   inline constexpr auto CallLHS = TokenDef("call-lhs");
   inline constexpr auto RefVarLHS = TokenDef("refvar-lhs");
   inline constexpr auto TupleFlatten = TokenDef("tupleflatten");
-  inline constexpr auto Bind = TokenDef("bind");
+  inline constexpr auto Bind = TokenDef("bind", flag::lookup | flag::shadowing);
 
   // Indexing names.
   inline constexpr auto IdSym = TokenDef("idsym");
-  inline constexpr auto Bounds = TokenDef("bounds");
+  inline constexpr auto Bound = TokenDef("bound");
   inline constexpr auto Default = TokenDef("default");
 
   // Rewrite identifiers.
@@ -120,30 +125,6 @@ namespace verona
   inline const auto apply = Location("apply");
   inline const auto load = Location("load");
   inline const auto store = Location("store");
-
-  struct Found
-  {
-    Node def;
-    NodeMap<Node> map;
-
-    Found() = default;
-    Found(const Found&) = default;
-    Found& operator=(const Found&) = default;
-
-    Found(Found&& that) : def(std::move(that.def)), map(std::move(that.map)) {}
-    Found(Node def) : def(def) {}
-
-    Found& operator|=(Found&& that)
-    {
-      def = std::move(that.def);
-      map.insert(that.map.begin(), that.map.end());
-      that.map.clear();
-      return *this;
-    }
-  };
-
-  Found resolve(Node typeName);
-  Node lookdown(Found& found, Node id);
 
   Parse parser();
   Driver& driver();

--- a/samples/verona/lookup.cc
+++ b/samples/verona/lookup.cc
@@ -1,27 +1,30 @@
 // Copyright Microsoft and Project Verona Contributors.
 // SPDX-License-Identifier: MIT
+#include "lookup.h"
+
 #include "lang.h"
 #include "wf.h"
 
 namespace verona
 {
-  void typeargs(Found& found, Node ta)
+  bool apply_typeargs(Lookup& lookup)
   {
-    // TODO: what if def is a TypeParam?
-    // use the bounds somehow?
-    if (!found.def || !ta)
-      return;
+    if (!lookup.ta)
+      return true;
 
-    // TODO: error node if it's something that doesn't take typeargs?
-    if (!found.def->type().in({Class, Function, TypeAlias}))
-      return;
+    if (!lookup.def->type().in({Class, TypeAlias}))
+      return false;
 
-    auto tp = found.def->at(
-      wf / Class / TypeParams,
-      wf / Function / TypeParams,
-      wf / TypeAlias / TypeParams);
+    auto ta = lookup.ta;
+    lookup.ta = {};
+    auto tp =
+      lookup.def->at(wf / Class / TypeParams, wf / TypeAlias / TypeParams);
 
-    // TODO: error node if there are too many typeargs?
+    // If we accept fewer type parameters than we have type arguments, it's not
+    // a valid lookup target.
+    if (tp->size() < ta->size())
+      return false;
+
     Nodes args{ta->begin(), ta->end()};
     args.resize(tp->size());
 
@@ -29,117 +32,146 @@ namespace verona
       tp->begin(),
       tp->end(),
       args.begin(),
-      std::inserter(found.map, found.map.end()),
+      std::inserter(lookup.bindings, lookup.bindings.end()),
       [](auto param, auto arg) { return std::make_pair(param, arg); });
+
+    return true;
   }
 
-  Found resolve(Node typeName)
+  Lookups lookdown(Lookups&& lookups, Node id, Node ta, NodeSet visited = {});
+
+  Lookups lookdown(Lookup& lookup, Node id, Node ta, NodeSet visited)
   {
-    Found found;
-    assert(typeName->type() == TypeName);
-    auto ctx = typeName->at(wf / TypeName / TypeName);
-    auto id = typeName->at(wf / TypeName / Ident);
-    auto ta = typeName->at(wf / TypeName / TypeArgs);
-
-    // A[T1, T2]::B[T3]::C[T4]
-    // ctx = A::B
-    // ctx = A
-    // found = A, {A_0 -> T1, A_1 -> T2}
-    // type A[A_0, A_1] = D[A_0]
-    //   found = scope_A::D, {D_0 -> A_0}
-    // found = scope_A::D::B, {A_0 -> T1, A_1 -> T2, B_0 -> T3}
-    // found = A::B::C, {A_0 -> T1, A_1 -> T2, B_0 -> T3, C_0 -> T4}
-
-    if (ctx->type() == TypeUnit)
-    {
-      found.def = id->lookup_first();
-    }
-    else if (ctx->type() == TypeName)
-    {
-      found = resolve(ctx);
-      if (!found.def)
-        return found;
-
-      found.def = lookdown(found, id);
-    }
-    else
-    {
-      assert(false && "unexpected type for TypeName context");
-    }
-
-    typeargs(found, ta);
-    return found;
-  }
-
-  Node lookdown(Found& found, Node id)
-  {
-    NodeSet visited;
-
     while (true)
     {
-      if (!found.def)
-        return {};
-
       // Check if we've visited this node before. If so, we've found a cycle.
-      auto [it, inserted] = visited.insert(found.def);
-      if (!inserted)
+      auto inserted = visited.insert(lookup.def);
+      if (!inserted.second)
         return {};
 
-      if (found.def->type().in({Class, TypeTrait}))
+      if (lookup.def->type().in({Class, TypeTrait}))
       {
-        return *found.def->lookdown(id).first;
-      }
-      else if (found.def->type() == TypeParam)
-      {
-        auto it = found.map.find(found.def);
-        if ((it != found.map.end()) && it->second)
-        {
-          found.def = it->second;
-          continue;
-        }
+        if (!apply_typeargs(lookup))
+          return {};
 
-        auto bounds = found.def->at(wf / TypeParam / Bounds);
-        if (!bounds->empty())
-        {
-          found.def = bounds;
-          continue;
-        }
-      }
-      else if (found.def->type() == TypeAlias)
-      {
-        found.def = found.def->at(wf / TypeAlias / Type);
-        continue;
-      }
-      else if (found.def->type() == Type)
-      {
-        found.def = found.def->at(wf / Type / Type);
-        continue;
-      }
-      else if (found.def->type() == TypeView)
-      {
-        found.def = found.def->at(wf / TypeView / rhs);
-        continue;
-      }
-      else if (found.def->type() == TypeThrow)
-      {
-        found.def = found.def->at(wf / TypeThrow / Type);
-        continue;
-      }
-      else if (found.def->type() == TypeName)
-      {
-        found |= resolve(found.def);
-        continue;
-      }
-      else if (found.def->type() == TypeIsect)
-      {
-        // TODO:
-      }
-      // TODO: typeisect, typeunion
+        // Return all lookdowns in the found class or trait.
+        Lookups result;
+        auto defs = lookup.def->lookdown(id->location());
 
-      // Other nodes don't have children to look down.
-      break;
+        std::transform(
+          defs.cbegin(),
+          defs.cend(),
+          std::back_inserter(result.defs),
+          [&](auto& def) {
+            return Lookup{def, ta, lookup.bindings};
+          });
+
+        return result;
+      }
+      else if (lookup.def->type() == TypeAlias)
+      {
+        if (!apply_typeargs(lookup))
+          return {};
+
+        // Replace the def with our type alias and try again.
+        lookup.def = lookup.def->at(wf / TypeAlias / Type);
+      }
+      else if (lookup.def->type() == TypeParam)
+      {
+        // Replace the typeparam with the bound typearg or, failing that, the
+        // upper bound, and try again.
+        auto it = lookup.bindings.find(lookup.def);
+
+        if ((it != lookup.bindings.end()) && it->second)
+          lookup.def = it->second;
+        else
+          lookup.def = lookup.def->at(wf / TypeParam / Bound);
+      }
+      // The remainder of cases arise from a Use, a TypeAlias, or a TypeParam.
+      // They will all result in some number of TypeName resolutions.
+      else if (lookup.def->type() == TypeName)
+      {
+        // Resolve the typename and try again. Pass `visited` into the resulting
+        // lookdowns, so that each path tracks cycles independently.
+        return lookdown(lookup_scopedname(lookup.def), id, ta, visited);
+      }
+      else if (lookup.def->type() == Type)
+      {
+        // Replace the def with the content of the type and try again.
+        lookup.def = lookup.def->at(wf / Type / Type);
+      }
+      else if (lookup.def->type() == TypeView)
+      {
+        // Replace the def with the rhs of the view and try again.
+        lookup.def = lookup.def->at(wf / TypeView / rhs);
+      }
+      else if (lookup.def->type() == TypeThrow)
+      {
+        // Replace the def with the throw type and try again.
+        lookup.def = lookup.def->at(wf / TypeThrow / Type);
+      }
+      else if (lookup.def->type() == TypeIsect)
+      {
+        // TODO: return everything we find
+        return {};
+      }
+      else if (lookup.def->type() == TypeUnion)
+      {
+        // TODO: return only things that are identical in all disjunctions
+        return {};
+      }
+      else
+      {
+        return {};
+      }
+    }
+  }
+
+  Lookups lookdown(Lookups&& lookups, Node id, Node ta, NodeSet visited)
+  {
+    Lookups result;
+
+    for (auto& lookup : lookups.defs)
+      result.add(lookdown(lookup, id, ta, visited));
+
+    return result;
+  }
+
+  Lookups lookup_name(Node id, Node ta)
+  {
+    assert(id->type().in({Ident, Symbol}));
+    assert(!ta || (ta->type() == TypeArgs));
+
+    Lookups lookups;
+    auto defs = id->lookup();
+
+    for (auto& def : defs)
+    {
+      // Expand Use nodes by looking down into the target type.
+      if (def->type() == Use)
+        lookups.add(lookdown({def->at(wf / Use / Type), {}}, id, ta));
+      else
+        lookups.add({def, ta});
     }
 
-    return {};
+    return lookups;
+  }
+
+  Lookups lookup_scopedname(Node tn)
+  {
+    assert(tn->type() == TypeName);
+    auto ctx = tn->at(wf / TypeName / TypeName);
+    auto id = tn->at(wf / TypeName / Ident);
+    auto ta = tn->at(wf / TypeName / TypeArgs);
+
+    if (ctx->type() == TypeUnit)
+      return lookup_name(id, ta);
+
+    return lookup_scopedname_name(ctx, id, ta);
+  }
+
+  Lookups lookup_scopedname_name(Node tn, Node id, Node ta)
+  {
+    return lookdown(lookup_scopedname(tn), id, ta);
   }
 }

--- a/samples/verona/parse.cc
+++ b/samples/verona/parse.cc
@@ -81,12 +81,12 @@ namespace verona
         // Terminator.
         ";" >> [](auto& m) { m.term(terminators); },
 
-        // FatArrow.
-        "=>" >>
+        // Function type or lambda.
+        "->" >>
           [indent](auto& m) {
             indent->back() = m.linecol().second + 1;
             m.term(terminators);
-            m.add(FatArrow);
+            m.add(Arrow);
             m.term(terminators);
           },
 

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -9,11 +9,6 @@ builtins
 
 list inside TypeParams or TypeArgs along with groups or other lists
 
-lookup
-- isect: lookup in lhs and rhs?
-- lookups in typetraits
-- error on too many typeargs
-
 `new` to create an instance of the enclosing class
 public/private
 object literals
@@ -25,14 +20,10 @@ CallLHS
 - `fun f()` vs `fun ref f()`
 - if a `ref` function has no non-ref implementation, autogenerate one that calls the `ref` function and does `load` on the result
 
-## Symbol Tables
+## Parse AST
 
-if symbol table lookup has multiple definitions
-  and any of them isn't a flag::multidef node
-  then error
-
-catch unexpected bindings as well
-  or generate bindings from wf conditions
+Use WF to parse an AST dump
+Know what tokens to expect, so know the strings that can be understood
 
 ## Ellipsis
 
@@ -116,6 +107,8 @@ pre (let x (try block1 catch block2)) post
 ## Lookup
 
 lookup in union and intersection types
+may need to check typealias bounds during lookup
+- `type foo: T` means a subtype must have a type alias `foo` that's a subtype of `T`.
 
 ## type checker
 
@@ -141,32 +134,3 @@ pattern match on type
   (type)
 pattern match on value
   (expr)
-
-## Type Language
-
-functions on types (functors, higher-kinded types)
-  kind is functor arity
-
-write functions of type->type explicitly?
-  treat any type alias as a function of type->type?
-
-use DontCare to create type lambdas?
-  `T: Array[_]`, `T[U]` -> `Array[U]`
-
-```ts
-type ?[T] = Some[T] | None
-type ->[T, U] = Fun[T, U]
-
-type Fun[T, U] =
-{
-  (self, x: T): U
-}
-
-x: ?[T] // awkward
-x: ?T // better - implies adjacency is application
-x: T.? // reverse application? prefer . as viewpoint
-x: Array U32 // awkward or good?
-
-type |[T, U] = Union[T, U] // no, unions are fundamental
-
-```

--- a/src/driver.h
+++ b/src/driver.h
@@ -54,6 +54,9 @@ namespace trieste
       bool diag = false;
       build->add_flag("-d,--diagnostics", diag, "Emit diagnostics.");
 
+      bool wfcheck = false;
+      build->add_flag("-w,--wf-check", wfcheck, "Check well-formedness.");
+
       std::string limit;
       build->add_option("-p,--pass", limit, "Run up to this pass.")
         ->transform(CLI::IsMember(limits));
@@ -123,7 +126,10 @@ namespace trieste
                         << changes << " nodes rewritten." << std::endl;
             }
 
-            if (wf && !wf.check(ast, std::cout))
+            if (wf)
+              wf.build_st(ast);
+
+            if (wfcheck && wf && !wf.check(ast, std::cout))
             {
               ret = -1;
               break;

--- a/src/pass.h
+++ b/src/pass.h
@@ -142,7 +142,6 @@ namespace trieste
               }
             }
 
-            match.bind();
             replaced = true;
             changes++;
             break;

--- a/src/rewrite.h
+++ b/src/rewrite.h
@@ -16,14 +16,10 @@ namespace trieste
 
   class Match
   {
-    friend class PassDef;
-
   private:
     Node in_node;
     std::map<Token, NodeRange> captures;
     std::map<Token, Node> defaults;
-    std::map<Location, Node> bindings;
-    std::vector<std::pair<Node, Node>> includes;
 
   public:
     Match(Node in_node) : in_node(in_node) {}
@@ -56,44 +52,10 @@ namespace trieste
       return {};
     }
 
-    Node operator()(LocBinding binding)
-    {
-      bindings[binding.first] = binding.second;
-      return binding.second;
-    }
-
-    Node operator()(Binding binding)
-    {
-      auto node = (*this)(binding.first);
-
-      if (!node)
-        throw std::runtime_error("Binding to undefined node");
-
-      bindings[node->location()] = binding.second;
-      return binding.second;
-    }
-
-    Node include(Node site, Node target)
-    {
-      includes.emplace_back(site, target);
-      return site;
-    }
-
     void operator+=(const Match& that)
     {
       captures.insert(that.captures.begin(), that.captures.end());
       defaults.insert(that.defaults.begin(), that.defaults.end());
-      bindings.insert(that.bindings.begin(), that.bindings.end());
-    }
-
-  private:
-    void bind()
-    {
-      for (auto& [loc, node] : bindings)
-        node->bind(loc);
-
-      for (auto& [site, target] : includes)
-        site->include(target);
     }
   };
 

--- a/src/source.h
+++ b/src/source.h
@@ -18,7 +18,6 @@ namespace trieste
   class NodeDef;
   using Source = std::shared_ptr<SourceDef>;
   using Node = std::shared_ptr<NodeDef>;
-  using LocBinding = std::pair<Location, Node>;
 
   class SourceDef
   {
@@ -203,12 +202,8 @@ namespace trieste
 
     bool before(const Location& that) const
     {
-      return (source != that.source) || (pos < that.pos);
-    }
-
-    LocBinding operator=(Node n) const
-    {
-      return {*this, n};
+      // Returns true if `this` overlaps or precedes `that` in the same source.
+      return (source == that.source) && (pos < (that.pos + that.len));
     }
 
     Location operator*(const Location& that) const

--- a/src/token.h
+++ b/src/token.h
@@ -7,7 +7,6 @@
 namespace trieste
 {
   struct Token;
-  using Binding = std::pair<Token, Node>;
 
   struct TokenDef
   {
@@ -21,10 +20,6 @@ namespace trieste
     TokenDef(const TokenDef&) = delete;
 
     operator Node() const;
-
-    Binding operator=(const TokenDef& token) const;
-    Binding operator=(const Token& token) const;
-    Binding operator=(Node n) const;
 
     constexpr bool has(TokenDef::flag f) const
     {
@@ -44,11 +39,6 @@ namespace trieste
     constexpr bool operator&(TokenDef::flag f) const
     {
       return (def->has(f)) != 0;
-    }
-
-    Binding operator=(Node n) const
-    {
-      return {*this, n};
     }
 
     constexpr bool operator==(const Token& that) const
@@ -81,7 +71,7 @@ namespace trieste
       return def >= that.def;
     }
 
-    constexpr bool in(std::initializer_list<Token> list) const
+    constexpr bool in(const std::initializer_list<Token>& list) const
     {
       return std::find(list.begin(), list.end(), *this) != list.end();
     }
@@ -92,28 +82,31 @@ namespace trieste
     }
   };
 
-  inline Binding TokenDef::operator=(const TokenDef& token) const
-  {
-    return {Token(*this), Token(token)};
-  }
-
-  inline Binding TokenDef::operator=(const Token& token) const
-  {
-    return {Token(*this), token};
-  }
-
-  inline Binding TokenDef::operator=(Node n) const
-  {
-    return {Token(*this), n};
-  }
-
   namespace flag
   {
     constexpr TokenDef::flag none = 0;
+
+    // Print the location when printing an AST node of this type.
     constexpr TokenDef::flag print = 1 << 0;
+
+    // Include a symbol table in an AST node of this type.
     constexpr TokenDef::flag symtab = 1 << 1;
+
+    // If an AST node of this type has a symbol table, definitions can only be
+    // found from later in the same source file.
     constexpr TokenDef::flag defbeforeuse = 1 << 2;
-    constexpr TokenDef::flag multidef = 1 << 3;
+
+    // If a definition of this type is in a symbol table, it don't recurse into
+    // parent symbol tables.
+    constexpr TokenDef::flag shadowing = 1 << 3;
+
+    // If a definition of this type is in a symbol table, it can be found when
+    // looking up.
+    constexpr TokenDef::flag lookup = 1 << 4;
+
+    // If a definition of this type in a symbol table, it can be found when
+    // looking down.
+    constexpr TokenDef::flag lookdown = 1 << 5;
   }
 
   inline constexpr auto Invalid = TokenDef("invalid");
@@ -124,6 +117,7 @@ namespace trieste
   inline constexpr auto Directory = TokenDef("directory");
   inline constexpr auto Seq = TokenDef("seq");
   inline constexpr auto Lift = TokenDef("lift");
+  inline constexpr auto Include = TokenDef("include");
   inline constexpr auto Error = TokenDef("error");
   inline constexpr auto ErrorMsg = TokenDef("errormsg", flag::print);
   inline constexpr auto ErrorAst = TokenDef("errorast");


### PR DESCRIPTION
Symbol tables are now auto-generated from well-formedness annotations. As part of this:
* Well-formedness checks are now enabled with `-w,--wf-check`
* Includes work in a language-agnostic way.
* `TokenDef` can specify which node types can be looked up and looked down, and which shadow lookups in parent scopes.