### PR TITLE
Parse an AST generated by any pass

### DIFF
--- a/include/trieste/parse.h
+++ b/include/trieste/parse.h
@@ -292,13 +292,13 @@ namespace trieste
       if (prefile_ && !prefile_(*this, filename))
         return {};
 
-      auto source = SourceDef::load(filename.string());
+      auto source = SourceDef::load(filename);
 
       if (!source)
         return {};
 
       auto make = detail::Make(filename.stem().string());
-      auto it = source->view().begin();
+      auto it = source->view().cbegin();
       auto st = it;
       auto end = source->view().cend();
 
@@ -315,7 +315,7 @@ namespace trieste
 
         for (auto& rule : find->second)
         {
-          matched = std::template regex_search(it, end, make.match_, rule.regex);
+          matched = std::regex_search(it, end, make.match_, rule.regex);
 
           if (matched)
           {

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -27,16 +28,9 @@ namespace trieste
     std::vector<size_t> lines;
 
   public:
-    static Source directory(const std::string& path)
+    static Source load(const std::filesystem::path& file)
     {
-      auto source = std::make_shared<SourceDef>();
-      source->origin_ = path;
-      return source;
-    }
-
-    static Source load(const std::string& file)
-    {
-      std::ifstream f(file.c_str(), std::ios::binary | std::ios::ate);
+      std::ifstream f(file, std::ios::binary | std::ios::in | std::ios::ate);
 
       if (!f)
         return {};

--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -46,9 +46,10 @@ namespace verona
   inline constexpr auto Let = TokenDef("let", flag::lookup | flag::shadowing);
   inline constexpr auto Ref = TokenDef("ref");
   inline constexpr auto Throw = TokenDef("throw");
-  inline constexpr auto Iso = TokenDef("iso");
-  inline constexpr auto Imm = TokenDef("imm");
-  inline constexpr auto Mut = TokenDef("mut");
+  inline constexpr auto Lin = TokenDef("lin");
+  inline constexpr auto In_ = TokenDef("in");
+  inline constexpr auto Out = TokenDef("out");
+  inline constexpr auto Const = TokenDef("const");
 
   // Semantic structure.
   inline constexpr auto TypeTrait = TokenDef("typetrait", flag::symtab);

--- a/samples/verona/parse.cc
+++ b/samples/verona/parse.cc
@@ -186,9 +186,10 @@ namespace verona
         "let\\b" >> [](auto& m) { m.add(Let); },
         "ref\\b" >> [](auto& m) { m.add(Ref); },
         "throw\\b" >> [](auto& m) { m.add(Throw); },
-        "iso\\b" >> [](auto& m) { m.add(Iso); },
-        "imm\\b" >> [](auto& m) { m.add(Imm); },
-        "mut\\b" >> [](auto& m) { m.add(Mut); },
+        "lin\\b" >> [](auto& m) { m.add(Lin); },
+        "in\\b" >> [](auto& m) { m.add(In_); },
+        "out\\b" >> [](auto& m) { m.add(Out); },
+        "const\\b" >> [](auto& m) { m.add(Const); },
 
         // Don't care.
         "_(?![_[:alnum:]])" >> [](auto& m) { m.add(DontCare); },

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -1,12 +1,11 @@
 # Todo
 
-minimum 1 thing in Expr?
-
 builtins
   if...else
   typetest
   match
 
+lazy[T]
 list inside TypeParams or TypeArgs along with groups or other lists
 
 `new` to create an instance of the enclosing class
@@ -19,11 +18,6 @@ CallLHS
 - separate implementation
 - `fun f()` vs `fun ref f()`
 - if a `ref` function has no non-ref implementation, autogenerate one that calls the `ref` function and does `load` on the result
-
-## Parse AST
-
-Use WF to parse an AST dump
-Know what tokens to expect, so know the strings that can be understood
 
 ## Ellipsis
 

--- a/samples/verona/std/test.verona
+++ b/samples/verona/std/test.verona
@@ -2,3 +2,9 @@ class I32
 {
 
 }
+
+// class ref[T]
+// {
+//   load(self): Self.T
+//   store(self: in, value: T): T
+// }


### PR DESCRIPTION
The AST emitted by Trieste is prepended with the rewriter name and the pass name that generated that AST. If the rewriter is given a `*.trieste` file, it checks that the rewriter name is the same, and then uses the well-formedness definition for the pass to parse the AST. The rewriter can then proceed from that pass onwards.

This allows the output of any pass to be saved and rewriting to be resumed later.
