### PR TITLE
Enable Trieste toolchains

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -425,7 +425,7 @@ namespace trieste
       ss << indent(level) << "(" << type_.str();
 
       if (type_ & flag::print)
-        ss << " " << location_.view();
+        ss << " " << location_.view().size() << ":" << location_.view();
 
       if (symtab_)
         ss << std::endl << symtab_->str(level + 1);


### PR DESCRIPTION
* Allow proceeding from any AST, regardless of label, that satisfies the parser WF.
* Use netstring encoding for AST node locations, to allow arbitrary characters.