### PR TITLE
Add conditionals to the Verona sample.

### DIFF
--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -50,6 +50,8 @@ namespace verona
   inline constexpr auto In_ = TokenDef("in");
   inline constexpr auto Out = TokenDef("out");
   inline constexpr auto Const = TokenDef("const");
+  inline constexpr auto If = TokenDef("if");
+  inline constexpr auto Else = TokenDef("else");
 
   // Semantic structure.
   inline constexpr auto TypeTrait = TokenDef("typetrait", flag::symtab);
@@ -103,6 +105,7 @@ namespace verona
   inline constexpr auto CallLHS = TokenDef("call-lhs");
   inline constexpr auto RefVarLHS = TokenDef("refvar-lhs");
   inline constexpr auto TupleFlatten = TokenDef("tupleflatten");
+  inline constexpr auto Conditional = TokenDef("conditional");
   inline constexpr auto Bind = TokenDef("bind", flag::lookup | flag::shadowing);
 
   // Indexing names.

--- a/samples/verona/parse.cc
+++ b/samples/verona/parse.cc
@@ -190,6 +190,8 @@ namespace verona
         "in\\b" >> [](auto& m) { m.add(In_); },
         "out\\b" >> [](auto& m) { m.add(Out); },
         "const\\b" >> [](auto& m) { m.add(Const); },
+        "if\\b" >> [](auto& m) { m.add(If); },
+        "else\\b" >> [](auto& m) { m.add(Else); },
 
         // Don't care.
         "_(?![_[:alnum:]])" >> [](auto& m) { m.add(DontCare); },

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -1,7 +1,6 @@
 # Todo
 
 builtins
-  if...else
   typetest
   match
 


### PR DESCRIPTION
This uses keywords for `if` and `else` to add conditionals to the Verona sample. This parsing should be the same as if `if` and `else` were programmable control flow, but in fact it's special cased to allow for type checking that knows that only one branch will be executed.
