### PR TITLE
Lambdas as anonymous types

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -333,12 +333,12 @@ namespace trieste
         symtab_->clear();
     }
 
-    Nodes lookup()
+    Nodes lookup(Node until = {})
     {
-      return lookup(location_);
+      return lookup(location_, until);
     }
 
-    Nodes lookup(const Location& loc)
+    Nodes lookup(const Location& loc, Node until = {})
     {
       auto st = scope();
       if (!st)
@@ -366,10 +366,13 @@ namespace trieste
         });
       }
 
-      // There are no shadowing definitions. Append any parent lookup results.
-      if (!std::any_of(result.begin(), result.end(), [](auto& n) {
-            return n->type() & flag::shadowing;
-          }))
+      // If we haven't reached the scope limit and there are no shadowing
+      // definitions, append any parent lookup results.
+      if (
+        (st != until) &&
+        !std::any_of(result.begin(), result.end(), [](auto& n) {
+          return n->type() & flag::shadowing;
+        }))
       {
         auto presult = st->lookup(loc);
         result.insert(result.end(), presult.begin(), presult.end());

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -377,6 +377,13 @@ namespace trieste
         loc, [](auto& n) { return n->type() & flag::lookdown; });
     }
 
+    Nodes look(const Location& loc)
+    {
+      // This is used for immediate resolution in the parent scope, ignoring
+      // flag::lookup and flag::lookdown.
+      return get_symbols(loc, [](auto&) { return true; });
+    }
+
     void bind(const Location& loc)
     {
       // Find the enclosing scope and bind the new location to this node in the
@@ -424,15 +431,22 @@ namespace trieste
       return node;
     }
 
-    void replace(Node node1, Node node2)
+    void replace(Node node1, Node node2 = {})
     {
       auto it = std::find(children.begin(), children.end(), node1);
       if (it == children.end())
         throw std::runtime_error("Node not found");
 
-      node1->parent_ = nullptr;
-      node2->parent_ = this;
-      it->swap(node2);
+      if (node2)
+      {
+        node1->parent_ = nullptr;
+        node2->parent_ = this;
+        it->swap(node2);
+      }
+      else
+      {
+        children.erase(it);
+      }
     }
 
     std::string str(size_t level = 0)

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -207,6 +207,15 @@ namespace trieste
       return children.back();
     }
 
+    void push_front(Node node)
+    {
+      if (!node)
+        return;
+
+      children.insert(children.begin(), node);
+      node->parent_ = this;
+    }
+
     void push_back(Node node)
     {
       if (!node)

--- a/include/trieste/defines.h
+++ b/include/trieste/defines.h
@@ -7,4 +7,3 @@
 #else
 #  define CONSTEVAL consteval
 #endif
-

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -265,6 +265,7 @@ namespace trieste
               std::cout << ss1.str();
 
             auto [new_ast, count, changes] = pass->run(ast);
+            wf.build_st(new_ast);
             ss2 << new_ast << "------------" << std::endl << std::endl;
 
             if (test_verbose)

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -31,7 +31,11 @@ namespace trieste
       Parse parser,
       wf::WellformedF wfParser,
       std::initializer_list<PassCheck> passes)
-    : language_name(language_name), app(language_name), parser(parser), wfParser(wfParser), passes(passes)
+    : language_name(language_name),
+      app(language_name),
+      parser(parser),
+      wfParser(wfParser),
+      passes(passes)
     {
       limits.push_back(parse_only);
 
@@ -120,6 +124,7 @@ namespace trieste
 
           if (view.compare(0, pos, language_name) == 0)
           {
+            // We're resuming from a specific pass.
             start_pass = pass_index(pass);
             end_pass = std::max(start_pass, end_pass);
 
@@ -138,6 +143,8 @@ namespace trieste
               return -1;
             }
 
+            // Build the AST, set up the symbol table, check well-formedness,
+            // and move on to the next pass.
             ast = wf.build_ast(source, pos2 + 1, std::cout);
             wf.build_st(ast);
             start_pass++;
@@ -147,6 +154,8 @@ namespace trieste
           }
           else
           {
+            // We're expecting an AST from another tool that fullfills our
+            // parser AST well-formedness definition.
             start_pass = 1;
             end_pass = std::max(start_pass, end_pass);
 
@@ -156,6 +165,7 @@ namespace trieste
               return -1;
             }
 
+            // Build the AST, set up the symbol table, check well-formedness,
             ast = wfParser.build_ast(source, pos2 + 1, std::cout);
             wfParser.build_st(ast);
 
@@ -165,6 +175,7 @@ namespace trieste
         }
         else
         {
+          // Parse the source path.
           ast = parser.parse(path);
 
           if (wfParser)
@@ -179,19 +190,22 @@ namespace trieste
 
         for (auto i = start_pass; i <= end_pass; i++)
         {
+          // Run the pass until it reaches a fixed point.
           auto& [pass_name, pass, wf] = passes.at(i - 1);
           auto [new_ast, count, changes] = pass->run(ast);
           ast = new_ast;
 
           if (diag)
           {
-            std::cout << "Pass " << pass_name << ": " << count << " iterations, "
-                      << changes << " nodes rewritten." << std::endl;
+            std::cout << "Pass " << pass_name << ": " << count
+                      << " iterations, " << changes << " nodes rewritten."
+                      << std::endl;
           }
 
           if (wf)
             wf.build_st(ast);
 
+          // Check well-formedness.
           if (wfcheck && wf && !wf.check(ast, std::cout))
           {
             end_pass = i;
@@ -209,7 +223,10 @@ namespace trieste
 
         if (f)
         {
-          f << language_name << std::endl << limits.at(end_pass) << std::endl << ast;
+          // Write the AST to the output file.
+          f << language_name << std::endl
+            << limits.at(end_pass) << std::endl
+            << ast;
         }
         else
         {
@@ -249,15 +266,15 @@ namespace trieste
 
           std::cout << "Testing pass: " << pass_name << std::endl;
 
-          for (size_t seed = test_seed; seed < test_seed + test_seed_count; seed++)
+          for (size_t seed = test_seed; seed < test_seed + test_seed_count;
+               seed++)
           {
             std::stringstream ss1;
             std::stringstream ss2;
 
             auto ast = prev.gen(seed, test_max_depth);
             ss1 << "============" << std::endl
-                << "Pass: " << pass_name << ", seed: " << seed
-                << std::endl
+                << "Pass: " << pass_name << ", seed: " << seed << std::endl
                 << "------------" << std::endl
                 << ast << "------------" << std::endl;
 
@@ -279,8 +296,8 @@ namespace trieste
                 std::cout << ss1.str() << ss2.str();
 
               std::cout << ss3.str() << "============" << std::endl
-                        << "Failed pass: " << pass_name
-                        << ", seed: " << seed << std::endl;
+                        << "Failed pass: " << pass_name << ", seed: " << seed
+                        << std::endl;
               ret = -1;
 
               if (test_failfast)

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -16,8 +16,8 @@ namespace trieste
   class PassDef
   {
   public:
-    using PreF = std::function<size_t()>;
-    using PostF = std::function<size_t()>;
+    using PreF = std::function<size_t(Node)>;
+    using PostF = std::function<size_t(Node)>;
 
   private:
     std::map<Token, PreF> pre_;
@@ -94,7 +94,7 @@ namespace trieste
 
       auto pre_f = pre_.find(node->type());
       if (pre_f != pre_.end())
-        changes += pre_f->second();
+        changes += pre_f->second(node);
 
       auto it = node->begin();
 
@@ -172,7 +172,7 @@ namespace trieste
 
       auto post_f = post_.find(node->type());
       if (post_f != post_.end())
-        changes += post_f->second();
+        changes += post_f->second(node);
 
       return changes;
     }

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -100,8 +100,8 @@ namespace trieste
 
       while (it != node->end())
       {
-        // Don't examine Error nodes.
-        if ((*it)->type() == Error)
+        // Don't examine Error or Lift nodes.
+        if ((*it)->type().in({Error, Lift}))
         {
           ++it;
           continue;
@@ -197,7 +197,7 @@ namespace trieste
         for (auto& lnode : lifted)
         {
           if (lnode->front()->type() == node->type())
-            it = node->insert(it, lnode->begin() + 1, lnode->end()) + 1;
+            it = node->insert(it, lnode->begin() + 1, lnode->end());
           else
             uplift.push_back(lnode);
         }

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -214,7 +214,7 @@ namespace trieste
       return {source, lo, hi - lo};
     }
 
-    Location operator*=(const Location& that)
+    Location& operator*=(const Location& that)
     {
       *this = *this * that;
       return *this;

--- a/include/trieste/token.h
+++ b/include/trieste/token.h
@@ -38,7 +38,7 @@ namespace trieste
 
     constexpr bool operator&(TokenDef::flag f) const
     {
-      return (def->has(f)) != 0;
+      return def->has(f);
     }
 
     constexpr bool operator==(const Token& that) const

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -75,7 +75,8 @@ namespace trieste
               out << "or ";
           }
 
-          out << std::endl << node->location().str() << std::endl;
+          out << std::endl
+              << node->location().str() << node->str() << std::endl;
         }
 
         return ok;
@@ -163,7 +164,7 @@ namespace trieste
         {
           out << node->location().origin_linecol() << "expected at least "
               << minlen << " children, found " << node->size() << std::endl
-              << node->location().str() << std::endl;
+              << node->location().str() << node->str() << std::endl;
           ok = false;
         }
 
@@ -172,7 +173,7 @@ namespace trieste
           out << node->location().origin_linecol() << "can't bind a "
               << node->type().str() << " sequence in the symbol table"
               << std::endl
-              << node->location().str() << std::endl;
+              << node->location().str() << node->str() << std::endl;
           ok = false;
         }
 
@@ -266,7 +267,7 @@ namespace trieste
             // Too few child nodes.
             out << node->location().origin_linecol()
                 << "too few child nodes in " << node->type().str() << std::endl
-                << node->location().str() << std::endl;
+                << node->location().str() << node->str() << std::endl;
             return false;
           }
           else
@@ -280,7 +281,7 @@ namespace trieste
           // Too many child nodes.
           out << (*child)->location().origin_linecol()
               << "too many child nodes in " << node->type().str() << std::endl
-              << (*child)->location().str() << std::endl;
+              << (*child)->location().str() << node->str() << std::endl;
           return false;
         }
         else
@@ -298,7 +299,7 @@ namespace trieste
               out << (*child)->location().origin_linecol()
                   << "missing symbol table binding for " << node->type().str()
                   << std::endl
-                  << (*child)->location().str() << std::endl;
+                  << (*child)->location().str() << node->str() << std::endl;
               ok = false;
             }
           }
@@ -442,8 +443,8 @@ namespace trieste
       {}
 
       template<typename... Ts1, typename... Ts2>
-      CONSTEVAL Wellformed(
-        const Wellformed<Ts1...>& wf1, const Wellformed<Ts2...>& wf2)
+      CONSTEVAL
+      Wellformed(const Wellformed<Ts1...>& wf1, const Wellformed<Ts2...>& wf2)
       : shapes(std::tuple_cat(wf1.shapes, wf2.shapes))
       {}
 
@@ -491,7 +492,7 @@ namespace trieste
           // Too many child nodes.
           out << node->location().origin_linecol() << "too many child nodes in "
               << node->type().str() << std::endl
-              << node->location().str() << std::endl;
+              << node->location().str() << node->str() << std::endl;
           return false;
         }
         else

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -290,7 +290,7 @@ namespace trieste
 
           if ((binding != Invalid) && (field.name == binding))
           {
-            auto defs = (*child)->lookup();
+            auto defs = node->scope()->look((*child)->location());
             auto find = std::find(defs.begin(), defs.end(), node);
 
             if (find == defs.end())

--- a/samples/verona/lang.cc
+++ b/samples/verona/lang.cc
@@ -773,7 +773,7 @@ namespace verona
 
   inline const auto Object0 = Literal / T(RefVar) / T(RefVarLHS) / T(RefLet) /
     T(Unit) / T(Tuple) / T(Lambda) / T(Call) / T(CallLHS) / T(Assign) /
-    T(Expr) / T(ExprSeq);
+    T(Expr) / T(ExprSeq) / T(DontCare);
   inline const auto Object = Object0 / (T(TypeAssert) << (Object0 * T(Type)));
   inline const auto Operator =
     T(New) / T(FunctionName) / T(Selector) / T(TypeAssertOp);
@@ -826,7 +826,10 @@ namespace verona
       T(Call)
           << (Operator[Op] *
               (T(Args)
-               << ((T(Expr) << !T(DontCare))++ * (T(Expr) << T(DontCare)) *
+               << ((T(Expr) << !T(DontCare))++ *
+                   (T(Expr)
+                    << (T(DontCare) /
+                        (T(TypeAssert) << (T(DontCare) * T(Type)[Type])))) *
                    T(Expr)++))[Args]) >>
         [](Match& _) {
           Node params = Params;
@@ -839,7 +842,7 @@ namespace verona
             if (arg->front()->type() == DontCare)
             {
               auto id = _.fresh();
-              params << (Param << (Ident ^ id) << typevar(_));
+              params << (Param << (Ident ^ id) << typevar(_, Type));
               args << (Expr << (RefLet << (Ident ^ id)));
             }
             else

--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -96,7 +96,6 @@ namespace verona
   inline constexpr auto Assign = TokenDef("assign");
   inline constexpr auto RefVar = TokenDef("refvar");
   inline constexpr auto RefLet = TokenDef("reflet");
-  inline constexpr auto RefFree = TokenDef("reffree");
   inline constexpr auto FunctionName = TokenDef("funcname");
   inline constexpr auto Selector = TokenDef("selector");
   inline constexpr auto Call = TokenDef("call");

--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -52,14 +52,14 @@ namespace verona
   inline constexpr auto Const = TokenDef("const");
   inline constexpr auto If = TokenDef("if");
   inline constexpr auto Else = TokenDef("else");
+  inline constexpr auto New = TokenDef("new");
 
   // Semantic structure.
-  inline constexpr auto TypeTrait = TokenDef("typetrait", flag::symtab);
+  inline constexpr auto TypeTrait =
+    TokenDef("typetrait", flag::symtab | flag::lookup | flag::shadowing);
   inline constexpr auto ClassBody = TokenDef("classbody");
-  inline constexpr auto FieldLet =
-    TokenDef("fieldlet", flag::symtab | flag::defbeforeuse | flag::lookdown);
-  inline constexpr auto FieldVar =
-    TokenDef("fieldvar", flag::symtab | flag::defbeforeuse | flag::lookdown);
+  inline constexpr auto FieldLet = TokenDef("fieldlet", flag::lookdown);
+  inline constexpr auto FieldVar = TokenDef("fieldvar", flag::lookdown);
   inline constexpr auto Function = TokenDef(
     "function",
     flag::symtab | flag::defbeforeuse | flag::lookup | flag::lookdown);
@@ -67,9 +67,8 @@ namespace verona
   inline constexpr auto TypeParam =
     TokenDef("typeparam", flag::lookup | flag::lookdown | flag::shadowing);
   inline constexpr auto Params = TokenDef("params");
-  inline constexpr auto Param = TokenDef(
-    "param",
-    flag::symtab | flag::defbeforeuse | flag::lookup | flag::shadowing);
+  inline constexpr auto Param =
+    TokenDef("param", flag::lookup | flag::shadowing);
   inline constexpr auto FuncBody = TokenDef("funcbody");
 
   // Type structure.
@@ -108,6 +107,7 @@ namespace verona
   inline constexpr auto Conditional = TokenDef("conditional");
   inline constexpr auto Bind = TokenDef("bind", flag::lookup | flag::shadowing);
   inline constexpr auto Move = TokenDef("move");
+  inline constexpr auto Copy = TokenDef("copy");
   inline constexpr auto Drop = TokenDef("drop");
 
   // Indexing names.

--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -69,7 +69,8 @@ namespace verona
   inline constexpr auto Params = TokenDef("params");
   inline constexpr auto Param =
     TokenDef("param", flag::lookup | flag::shadowing);
-  inline constexpr auto FuncBody = TokenDef("funcbody");
+  inline constexpr auto Block =
+    TokenDef("block", flag::symtab | flag::defbeforeuse);
 
   // Type structure.
   inline constexpr auto Type = TokenDef("type");

--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -96,6 +96,7 @@ namespace verona
   inline constexpr auto Assign = TokenDef("assign");
   inline constexpr auto RefVar = TokenDef("refvar");
   inline constexpr auto RefLet = TokenDef("reflet");
+  inline constexpr auto RefFree = TokenDef("reffree");
   inline constexpr auto FunctionName = TokenDef("funcname");
   inline constexpr auto Selector = TokenDef("selector");
   inline constexpr auto Call = TokenDef("call");
@@ -131,6 +132,7 @@ namespace verona
   inline const auto apply = Location("apply");
   inline const auto load = Location("load");
   inline const auto store = Location("store");
+  inline const auto self = Location("self");
 
   Parse parser();
   Driver& driver();

--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -94,6 +94,7 @@ namespace verona
   inline constexpr auto Lambda =
     TokenDef("lambda", flag::symtab | flag::defbeforeuse);
   inline constexpr auto Tuple = TokenDef("tuple");
+  inline constexpr auto Unit = TokenDef("unit");
   inline constexpr auto Assign = TokenDef("assign");
   inline constexpr auto RefVar = TokenDef("refvar");
   inline constexpr auto RefLet = TokenDef("reflet");

--- a/samples/verona/lookup.h
+++ b/samples/verona/lookup.h
@@ -47,7 +47,7 @@ namespace verona
 
     bool one(const std::initializer_list<Token>& types) const
     {
-      return (defs.size()) == 1 && defs.front().def->type().in(types);
+      return (defs.size() == 1) && defs.front().def->type().in(types);
     }
   };
 

--- a/samples/verona/parse.cc
+++ b/samples/verona/parse.cc
@@ -192,6 +192,7 @@ namespace verona
         "const\\b" >> [](auto& m) { m.add(Const); },
         "if\\b" >> [](auto& m) { m.add(If); },
         "else\\b" >> [](auto& m) { m.add(Else); },
+        "new\\b" >> [](auto& m) { m.add(New); },
 
         // Don't care.
         "_(?![_[:alnum:]])" >> [](auto& m) { m.add(DontCare); },

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -36,6 +36,10 @@ get rid of `throw` as a keyword
 - it's a type, like return, break, continue
 add `try`
 
+could allow `->` as a user defined symbol
+- consume only the first `->` in a lambda definition
+- after `typefunc`, convert it to a symbol
+
 ## Partial Application with DontCare
 
 what does `f _ x` compile to?
@@ -51,14 +55,12 @@ CallLHS
 ## Lambdas
 
 selectors and functionnames as values
+- an unbound selector must be a valid functionname
 - can we wrap them in a lambda?
-- that makes all types `T1->T2` sugar for `{ apply(Self, T1...): T2 }`
-
-using lambdas for default initialisers
-- no wrapping funcbody when we do anf
-
-free variables in lambdas
-- for if/else, each lambda is "last" or not independently
+  - `f` ~> `{ $0 -> f $0 }`
+  - gives us a function that takes a single argument
+  - if it has more arguments, this gets us back the partial application
+- makes all types `T1...->T2` sugar for `{ apply(Self, T1...): T2 }`
 
 type of the lambda:
 - no captures, or all captures are `const` = `const`, `self: const`

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -37,13 +37,9 @@ get rid of `throw` as a keyword
 add `try`
 
 could allow `->` as a user defined symbol
+- allow as a function name
 - consume only the first `->` in a lambda definition
 - after `typefunc`, convert it to a symbol
-
-## Partial Application with DontCare
-
-what does `f _ x` compile to?
-- want `{ $0 -> f $0 x }`, but that's probably not working right
 
 ## `ref` Functions
 

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -11,46 +11,42 @@ object literals
 public/private
 package schemes
 type assertions are accidentally allowed as types
+allow assignment to DontCare
 
 ## Conditionals
 
-need to do `(call (selector apply typeargs) lambda args)` on both sides
-- anf needs to preserve these groupings
-- the lambda create can't get lifted
-- does wrapping in a FuncBody work?
-  - no, it's messing up move/copy/drop
-  - also messing up lifting anonymous types
+early exit
+- breaks things, the other branch doesn't join with us
+- need all moves/drops in any continuation
 
-another pass, after `drop`, to handle move/copy/drop in conditionals
-
-conditional
-  reflet
-  on-true
-    $0 = ... reflet0*
-    (∀ id . move id ∈ reflet1* ∧ copy id ∈ reflet0*) (copy id -> move id)
-    (∀ id . move id ∈ reflet1* ∧ move id ∉ reflet0*) drop id
-    apply $0 noargs
-  on-false
-    $0 = ... reflet1*
-    (∀ id . move id ∈ reflet0* ∧ move id ∉ reflet1*) drop id
-    apply $0 noargs
+type test conditionals
 
 ## Build ST
 
 two `shadowing` defs of the same symbol in the same scope should produce an error
 
+## Key Words
+
+get rid of the `package` keyword
+- accept a string as a type, indicating a package
+get rid of capabilities as keywords
+- make them types in `std`?
+- or just handle those `typename` nodes specially in the typechecker?
+get rid of `throw` as a keyword
+- it's a type, like return, break, continue
+add `try`
+
+## Partial Application with DontCare
+
+what does `f _ x` compile to?
+- want `{ $0 -> f $0 x }`, but that's probably not working right
+
 ## `ref` Functions
 
 CallLHS
 - separate implementation
-- `fun f()` vs `fun ref f()`
+- `f()` vs `ref f()`
 - if a `ref` function has no non-ref implementation, autogenerate one that calls the `ref` function and does `load` on the result
-
-## Exceptions and Drop
-
-when we hit a `throw`, we need to `drop` anything that's still in scope
-- the issue is dropping variables out of the parent scope of a lambda
-- same thing can happen for any `call`
 
 ## Lambdas
 

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -12,6 +12,10 @@ public/private
 package schemes
 type assertions are accidentally allowed as types
 
+## Conditionals
+
+not lambdas?
+
 ## Build ST
 
 two `shadowing` defs of the same symbol in the same scope should produce an error
@@ -51,6 +55,7 @@ type of the lambda:
 
 if a tuple field is `lin`, it's not `lin` in the destructuring bind
 if the tuple itself is also `lin`, can we make this work?
+the same thing happens with lambda captures
 
 ## Type Inference
 

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -14,7 +14,26 @@ type assertions are accidentally allowed as types
 
 ## Conditionals
 
-not lambdas?
+need to do `(call (selector apply typeargs) lambda args)` on both sides
+- anf needs to preserve these groupings
+- the lambda create can't get lifted
+- does wrapping in a FuncBody work?
+  - no, it's messing up move/copy/drop
+  - also messing up lifting anonymous types
+
+another pass, after `drop`, to handle move/copy/drop in conditionals
+
+conditional
+  reflet
+  on-true
+    $0 = ... reflet0*
+    (∀ id . move id ∈ reflet1* ∧ copy id ∈ reflet0*) (copy id -> move id)
+    (∀ id . move id ∈ reflet1* ∧ move id ∉ reflet0*) drop id
+    apply $0 noargs
+  on-false
+    $0 = ... reflet1*
+    (∀ id . move id ∈ reflet0* ∧ move id ∉ reflet1*) drop id
+    apply $0 noargs
 
 ## Build ST
 
@@ -33,7 +52,7 @@ when we hit a `throw`, we need to `drop` anything that's still in scope
 - the issue is dropping variables out of the parent scope of a lambda
 - same thing can happen for any `call`
 
-## Free Variables
+## Lambdas
 
 selectors and functionnames as values
 - can we wrap them in a lambda?

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -114,18 +114,19 @@ typeof (move $0) =
 
 `expr...` flattens the tuple produced by `expr`
 - only needed when putting `expr...` in another tuple
+
 `T...` is a tuple of unknown arity (0 or more) where every element is a `T`
 - `T...` in a tuple flattens the type into the tuple
 - `T...` in a function type flattens the type into the function arguments
 
 ```ts
 // multiply a tuple of things by a thing
-mul[n: type {*(n, n): n}, a: n...](x: n, y: a): a
+mul[n: {*(n, n): n}, a: n...](x: n, y: a): a
 {
   match y
   {
-    { () => () }
-    { y, ys => x * y, mul(x, ys)... }
+    { _: () -> () }
+    { y, ys -> x * y, mul(x, ys)... }
   }
 }
 

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -31,57 +31,21 @@ when we hit a `throw`, we need to `drop` anything that's still in scope
 
 ## Free Variables
 
+selectors and functionnames as values
+- can we wrap them in a lambda?
+- that makes all types `T1->T2` sugar for `{ apply(Self, T1...): T2 }`
+
+using lambdas for default initialisers
+- no wrapping funcbody when we do anf
+
 free variables in lambdas
-- create field initializers?
-  - if it's the last reference to `$0`, we'll get `move`
-  - for if/else, each lambda is "last" or not independently
-- free `refvar` are captured by `ref[T]`, `reflet` are dup'd or moved
-  - this is just "never `load`" when capturing, but load as usual in the body of the lambda
-- type of the lambda:
-  - no captures, or all captures are `const` = `const`, `self: const`
-  - any `lin` captures = `lin`, `self: lin`
-  - 0 `lin`, 1 or more `in`, 0 or more `const` = `lin`, `self: in`
-  - don't know if any `out` captures
+- for if/else, each lambda is "last" or not independently
 
-```ts
-{ p1, p2 -> ... x ... y ... }
-
-class $0
-{
-  let x: $T1
-  let y: $T2
-
-  create(x: $T1, y: $T1): $0 & lin = new (x, y)
-
-  apply(self, p1, p2...): _
-  {
-    // Self.$T1, losing `lin`
-    // if Self <: lin, can change the type of Self here and extract `lin`
-    let x = self.x
-    let y = self.y
-  }
-}
-
-(class
-  (ident $0)
-  (typeparams)
-  (type)
-  (classbody
-    (fieldlet (ident $freevar) (type (typevar $2)) (dontcare))
-    (function (ident create) (typeparams)
-      (params (param (ident $freevar) (type (typevar $2)) (dontcare)))
-      (type (typename typeunit (ident $0) typeargs))
-      (funcbody
-        (call new (args (ident $freevar)))))
-    (function (ident apply) (typeparams)
-      (params
-        (param (ident self) (type (typename typeunit (ident Self))) (dontcare))
-         ...)
-      (type (typevar $3))
-      (funcbody
-        (let (ident $freevar) (type (typevar $2))
-          (call (ident $1) (args (ident $1))))))))
-```
+type of the lambda:
+- no captures, or all captures are `const` = `const`, `self: const`
+- any `lin` captures = `lin`, `self: lin`
+- 0 `lin`, 1 or more `in`, 0 or more `const` = `lin`, `self: in`
+- don't know if any `out` captures
 
 ## Destructuring Binds and `lin`
 

--- a/samples/verona/std/test.verona
+++ b/samples/verona/std/test.verona
@@ -1,6 +1,6 @@
 class I32
 {
-
+  +(self, other: I32): I32 = @llvm "add i32 %self %other"
 }
 
 // class ref[T]

--- a/samples/verona/wf.h
+++ b/samples/verona/wf.h
@@ -9,7 +9,7 @@ namespace verona
   using namespace wf::ops;
 
   inline constexpr auto wfIdSym = IdSym >>= Ident | Symbol;
-  inline constexpr auto wfDefault = Default >>= Block | DontCare;
+  inline constexpr auto wfDefault = Default >>= Expr | DontCare;
 
   inline constexpr auto wfLiteral =
     Bool | Int | Hex | Bin | Float | HexFloat | Char | Escaped | String;
@@ -93,8 +93,15 @@ namespace verona
   // clang-format on
 
   // clang-format off
-  inline constexpr auto wfPassTypeView =
+  inline constexpr auto wfPassDefaultArgs =
       wfPassStructure
+    | (Param <<= Ident * Type)[Ident]
+    ;
+  // clang-format on
+
+  // clang-format off
+  inline constexpr auto wfPassTypeView =
+      wfPassDefaultArgs
 
     // Add TypeName, TypeView, TypeList.
     | (TypeName <<= (TypeName >>= (TypeName | TypeUnit)) * Ident * TypeArgs)
@@ -335,10 +342,10 @@ namespace verona
   inline constexpr auto wf =
       (TypeAlias <<= Ident * TypeParams * (Bound >>= Type) * (Default >>= Type))
     | (Class <<= Ident * TypeParams * Type * ClassBody)
-    | (FieldLet <<= Ident * Type * Expr)
-    | (FieldVar <<= Ident * Type * Expr)
+    | (FieldLet <<= Ident * Type * Default)
+    | (FieldVar <<= Ident * Type * Default)
     | (Function <<= wfIdSym * TypeParams * Params * (Type >>= wfType) * Block)
-    | (Param <<= Ident * Type * Expr)
+    | (Param <<= Ident * Type * Default)
     | (Type <<= wfType)
     | (TypeName <<= (TypeName >>= (TypeName | TypeUnit)) * Ident * TypeArgs)
     | (TypeView <<= (Lhs >>= wfType) * (Rhs >>= wfType))

--- a/samples/verona/wf.h
+++ b/samples/verona/wf.h
@@ -189,16 +189,30 @@ namespace verona
     // Add RefLet, RefVar, Selector, FunctionName, TypeAssertOp.
     | (RefLet <<= Ident)
     | (RefVar <<= Ident)
+    | (RefFree <<= Ident)
     | (Selector <<= wfIdSym * TypeArgs)
     | (FunctionName <<= (TypeName >>= (TypeName | TypeUnit)) * Ident * TypeArgs)
     | (TypeAssertOp <<= (Op >>= Selector | FunctionName) * Type)
 
     // Remove TypeArgs, Ident, Symbol, DoubleColon.
-    // Add RefVar, RefLet, Selector, FunctionName, TypeAssertOp.
+    // Add RefVar, RefLet, RefFree, Selector, FunctionName, TypeAssertOp.
     | (Expr <<=
         (Expr | ExprSeq | Tuple | Assign | Lambda | Let | Var | Throw | If |
          Else | New | Ref | DontCare | Ellipsis | Dot | wfLiteral | TypeAssert |
-         RefVar | RefLet | Selector | FunctionName | TypeAssertOp)++[1])
+         RefVar | RefLet | RefFree | Selector | FunctionName |
+         TypeAssertOp)++[1])
+    ;
+  // clang-format on
+
+  // clang-format off
+  inline constexpr auto wfPassLambda =
+      wfPassReference
+
+    // Remove RefFree, Lambda.
+    | (Expr <<=
+        (Expr | ExprSeq | Tuple | Assign | Let | Var | Throw | If | Else | New |
+         Ref | DontCare | Ellipsis | Dot | wfLiteral | TypeAssert | RefVar |
+         RefLet | Selector | FunctionName | TypeAssertOp)++[1])
     ;
   // clang-format on
 
@@ -213,9 +227,9 @@ namespace verona
 
     // Remove Dot. Add Call.
     | (Expr <<=
-        (Expr | ExprSeq | Tuple | Assign | Lambda | Let | Var | Throw | If |
-         Else | New | Ref | DontCare | Ellipsis | wfLiteral | TypeAssert |
-         RefVar | RefLet | Selector | FunctionName | TypeAssertOp | Call)++[1])
+        (Expr | ExprSeq | Tuple | Assign | Let | Var | Throw | If | Else | New |
+         Ref | DontCare | Ellipsis | wfLiteral | TypeAssert | RefVar | RefLet |
+         Selector | FunctionName | TypeAssertOp | Call)++[1])
     ;
   // clang-format on
 
@@ -226,12 +240,11 @@ namespace verona
     // Add Conditional.
     | (Conditional <<= Expr * (Lhs >>= Lambda) * (Rhs >>= Conditional | Lambda))
 
-    // Remove DontCare, Ellipsis. Add Conditional, TupleFlatten.
+    // Remove New, DontCare, Ellipsis. Add Conditional, TupleFlatten.
     | (Expr <<=
-        (Expr | ExprSeq | Tuple | Assign | Lambda | Let | Var | Throw | If |
-         Else | New | Ref | wfLiteral | TypeAssert | RefVar | RefLet |
-         Selector | FunctionName | TypeAssertOp | Call | Conditional |
-         TupleFlatten)++[1])
+        (Expr | ExprSeq | Tuple | Assign | Let | Var | Throw | If | Else | Ref |
+         wfLiteral | TypeAssert | RefVar | RefLet | Selector | FunctionName |
+         TypeAssertOp | Call | Conditional | TupleFlatten)++[1])
     ;
   // clang-format on
 
@@ -245,11 +258,11 @@ namespace verona
     | (CallLHS <<=
         (Selector >>= (Selector | FunctionName | TypeAssertOp)) * Args)
 
-    // Remove Expr, Ref, If, Else, New. Add TupleLHS, CallLHS, RefVarLHS.
+    // Remove Expr, Ref, If, Else. Add TupleLHS, CallLHS, RefVarLHS.
     | (Expr <<=
-        ExprSeq | Tuple | Assign | Lambda | Let | Var | Throw | wfLiteral |
-        TypeAssert | RefVar | RefLet | Selector | FunctionName | TypeAssertOp |
-        Call | Conditional | TupleFlatten | TupleLHS | CallLHS | RefVarLHS)
+        ExprSeq | Tuple | Assign | Let | Var | Throw | wfLiteral | TypeAssert |
+        RefVar | RefLet | Selector | FunctionName | TypeAssertOp | Call |
+        Conditional | TupleFlatten | TupleLHS | CallLHS | RefVarLHS)
     ;
   // clang-format on
 
@@ -259,9 +272,9 @@ namespace verona
 
     // Remove Var, RefVar, RefVarLHS.
     | (Expr <<=
-        ExprSeq | Tuple | Assign | Lambda | Let | Throw | wfLiteral |
-        TypeAssert | RefLet | Selector | FunctionName | TypeAssertOp | Call |
-        Conditional | TupleFlatten | TupleLHS | CallLHS)
+        ExprSeq | Tuple | Assign | Let | Throw | wfLiteral | TypeAssert |
+        RefLet | Selector | FunctionName | TypeAssertOp | Call | Conditional |
+        TupleFlatten | TupleLHS | CallLHS)
     ;
   // clang-format on
 
@@ -274,9 +287,9 @@ namespace verona
 
     // Remove Assign, Let, TupleLHS. Add Bind.
     | (Expr <<=
-        ExprSeq | Tuple | Lambda | Throw | wfLiteral | TypeAssert | RefLet |
-        Selector | FunctionName | TypeAssertOp | Call | Conditional |
-        TupleFlatten | CallLHS | Bind)
+        ExprSeq | Tuple | Throw | wfLiteral | TypeAssert | RefLet | Selector |
+        FunctionName | TypeAssertOp | Call | Conditional | TupleFlatten |
+        CallLHS | Bind)
     ;
   // clang-format on
 
@@ -294,7 +307,7 @@ namespace verona
     | (TypeAssert <<= Ident * Type)
     | (Bind <<= Ident * Type *
         (Rhs >>=
-          RefLet | Tuple | Lambda | Call | Conditional | CallLHS | Selector |
+          RefLet | Tuple | Call | Conditional | CallLHS | Selector |
           FunctionName | wfLiteral))[Ident]
     ;
   // clang-format on
@@ -319,8 +332,8 @@ namespace verona
         (Rhs >>= Lambda | Conditional))
     | (Bind <<= Ident * Type *
         (Rhs >>=
-          Tuple | Lambda | Call | Conditional | CallLHS | Selector |
-          FunctionName | wfLiteral | Copy | Move))[Ident]
+          Tuple | Call | Conditional | CallLHS | Selector | FunctionName |
+          wfLiteral | Copy | Move))[Ident]
     ;
   // clang-format on
 
@@ -346,7 +359,7 @@ namespace verona
     | (TypeAssert <<= RefLet * Type)
     | (Bind <<= Ident * Type *
         (Rhs >>=
-          RefLet | Tuple | Lambda | Call | Conditional | CallLHS | Selector |
+          RefLet | Tuple | Call | Conditional | CallLHS | Selector |
           FunctionName | wfLiteral))
     ;
   // clang-format on

--- a/samples/verona/wf.h
+++ b/samples/verona/wf.h
@@ -93,15 +93,8 @@ namespace verona
   // clang-format on
 
   // clang-format off
-  inline constexpr auto wfPassDefaultArgs =
-      wfPassStructure
-    | (Param <<= Ident * Type)[Ident]
-    ;
-  // clang-format on
-
-  // clang-format off
   inline constexpr auto wfPassTypeView =
-      wfPassDefaultArgs
+      wfPassStructure
 
     // Add TypeName, TypeView, TypeList.
     | (TypeName <<= (TypeName >>= (TypeName | TypeUnit)) * Ident * TypeArgs)
@@ -302,8 +295,15 @@ namespace verona
   // clang-format on
 
   // clang-format off
-  inline constexpr auto wfPassANF =
+  inline constexpr auto wfPassDefaultArgs =
       wfPassLambda
+    | (Param <<= Ident * Type)[Ident]
+    ;
+  // clang-format on
+
+  // clang-format off
+  inline constexpr auto wfPassANF =
+      wfPassDefaultArgs
     | (Block <<= (Use | Class | TypeAlias | Bind | RefLet)++)
     | (Tuple <<= (RefLet | TupleFlatten)++[2])
     | (TupleFlatten <<= RefLet)


### PR DESCRIPTION
Lambdas are rewritten as anonymous types, so that by the time the ANF pass is running, lambdas no longer exist. This also improves support for conditionals, tracking `move` and `drop` correctly in both branches.