### PR TITLE
Use _ to ignore a parameter or a binding

### DIFF
--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -1,15 +1,14 @@
 # Todo
 
-- mixins
 - non-local returns
+- mixins
 - lazy[T]
-- list inside TypeParams or TypeArgs along with groups or other lists
 - object literals
+- match
 - public/private
 - package schemes
 - type assertions are accidentally allowed as types
-- allow assignment to DontCare
-- match
+- list inside TypeParams or TypeArgs along with groups or other lists
 
 ## Conditionals
 


### PR DESCRIPTION
You can use `_` (DontCare) as a parameter name (where it will get a fresh identifier, and so be unnameable), and you can use it in an expression, where it becomes `let _`, where `_` is again a fresh identifier.
