### PR TITLE
Object literals

### DIFF
--- a/samples/verona/lang.cc
+++ b/samples/verona/lang.cc
@@ -317,6 +317,18 @@ namespace verona
       In(TypeArgs) * T(Paren)[Type] >>
         [](Match& _) { return Type << *_[Type]; },
 
+      // Object literal.
+      In(Expr) * T(New) * T(Brace)[ClassBody] >>
+        [](Match& _) {
+          auto class_id = _.fresh();
+          return Seq << (Lift
+                         << Block
+                         << (Class << (Ident ^ class_id) << TypeParams << Type
+                                   << (ClassBody << *_[ClassBody])))
+                     << (Expr << (Ident ^ class_id) << DoubleColon
+                              << (Ident ^ create) << Unit);
+        },
+
       // Conditionals are right-associative.
       In(Expr) * T(If) * (!T(Brace))++[Expr] * T(Brace)[Lhs] *
           (T(Else) * T(If) * (!T(Brace))++ * T(Brace))++[Op] *

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -3,7 +3,6 @@
 - non-local returns
 - mixins
 - lazy[T]
-- object literals
 - match
 - public/private
 - package schemes


### PR DESCRIPTION
A `ClassBody` is already used to define a `class` or an anonymous structural type. Now, `new` followed immediately by `{ ... }` is an object literal, where the `ClassBody` defined by `{ ... }` is a new anonymous class.