### PR TITLE
Allow custom locations when generating a synthetic AST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,14 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(cli11)
 
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt
+  GIT_TAG        9.1.0
+)
+
+FetchContent_MakeAvailable(fmt)
+
 ##############################################
 # Options
 
@@ -37,7 +45,8 @@ target_compile_features(trieste INTERFACE cxx_std_20)
 if(MSVC)
   target_compile_options(trieste INTERFACE /W4 /WX /bigobj)
 else()
-  target_compile_options(trieste INTERFACE -Wall -Wextra -Wpedantic -Werror -Wshadow)
+  target_compile_options(trieste INTERFACE
+    -Wall -Wextra -Wpedantic -Werror -Wshadow)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -284,7 +284,7 @@ namespace trieste
             std::stringstream ss1;
             std::stringstream ss2;
 
-            auto ast = prev.gen(seed, test_max_depth);
+            auto ast = prev.gen(parser.generators(), seed, test_max_depth);
             ss1 << "============" << std::endl
                 << "Pass: " << pass_name << ", seed: " << seed << std::endl
                 << "------------" << std::endl

--- a/include/trieste/gen.h
+++ b/include/trieste/gen.h
@@ -1,0 +1,20 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "ast.h"
+#include "xoroshiro.h"
+
+#include <regex>
+
+namespace trieste
+{
+  using sv_match = std::match_results<std::string_view::const_iterator>;
+
+  using Rand = xoroshiro::p128r32;
+  using Seed = uint64_t;
+  using Result = uint32_t;
+
+  using GenLocationF = std::function<std::string(Rand& rnd)>;
+  using GenNodeLocationF = std::function<Location(Rand&, Node)>;
+}

--- a/include/trieste/xoroshiro.h
+++ b/include/trieste/xoroshiro.h
@@ -33,7 +33,7 @@ namespace xoroshiro
         if (x_ == 0 && y_ == 0)
           abort();
 
-        next();
+        (*this)();
       }
 
       void set_state(STATE x_, STATE y_ = 0)
@@ -44,10 +44,20 @@ namespace xoroshiro
 
         x = x_;
         y = y_;
-        next();
+        (*this)();
       }
 
-      RESULT next()
+      RESULT min() const
+      {
+        return std::numeric_limits<RESULT>::min();
+      }
+
+      RESULT max() const
+      {
+        return std::numeric_limits<RESULT>::max();
+      }
+
+      RESULT operator()()
       {
         STATE r = x + y;
         y ^= x;

--- a/samples/verona/CMakeLists.txt
+++ b/samples/verona/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(verona
 target_link_libraries(verona
   Threads::Threads
   CLI11::CLI11
+  fmt::fmt
   trieste::trieste
   )
 

--- a/samples/verona/lang.cc
+++ b/samples/verona/lang.cc
@@ -330,8 +330,8 @@ namespace verona
         },
 
       // Conditionals are right-associative.
-      In(Expr) * T(If) * (!T(Brace))++[Expr] * T(Brace)[Lhs] *
-          (T(Else) * T(If) * (!T(Brace))++ * T(Brace))++[Op] *
+      In(Expr) * T(If) * (!T(Brace) * (!T(Brace))++)[Expr] * T(Brace)[Lhs] *
+          (T(Else) * T(If) * (!T(Brace) * !T(Brace))++ * T(Brace))++[Op] *
           ~(T(Else) * T(Brace)[Rhs]) >>
         [](Match& _) {
           // Pack all of the branches into a single conditional and unpack them

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -1,5 +1,6 @@
 # Todo
 
+- free variables in object literals
 - non-local returns
 - mixins
 - lazy[T]
@@ -88,6 +89,8 @@ typeof (reflet $0) =
 - dup(node->lookup()->at(wf / Bind / Type)) // dup drops `lin`?
 typeof (move $0) =
 - node->lookup()->at(wf / Bind / Type) // no dup
+
+A `var` field has both a `ref` accessor function and a non-`ref` accessor function. A `let` field has only a non-`ref` accessor field. This means a `var x: T1` field is a subtype of a `let x: T2` field if `T1 <: T2`. However, a `var x: T1` field is only a subtype of a `var x: T2` field if `(T1 <: T2) ∧ (T2 <: T1)`, because the `ref` accessors return `ref[T1]` and `ref[T2]` respectively.
 
 ## Lowering
 


### PR DESCRIPTION
In your parser, you can specify generator functions for specific AST node types. This is only used during testing, when generating synthetic AST nodes.
