### PR TITLE
Add TypeTest conditionals

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -5,6 +5,7 @@
 #include "token.h"
 
 #include <limits>
+#include <iostream>
 #include <map>
 #include <set>
 #include <sstream>
@@ -572,5 +573,10 @@ namespace trieste
     for (auto it = range.first; it != range.second; ++it)
       os << (*it)->str();
     return os;
+  }
+
+  inline void print(const Node& node)
+  {
+    std::cout << node;
   }
 }

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -45,6 +45,9 @@ namespace trieste
 
     int run(int argc, char** argv)
     {
+      // This is only present to allow running `print` in the debugger.
+      print({});
+
       parser.executable(argv[0]);
 
       app.set_help_all_flag("--help-all", "Expand all help");

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -216,25 +216,31 @@ namespace trieste
 
       while (it != node->end())
       {
+        bool advance = true;
         auto lifted = lift(*it);
-        bool removed = false;
 
         if ((*it)->type() == Lift)
         {
-          lifted.push_back(*it);
+          lifted.insert(lifted.begin(), *it);
           it = node->erase(it, it + 1);
-          removed = true;
+          advance = false;
         }
 
         for (auto& lnode : lifted)
         {
           if (lnode->front()->type() == node->type())
+          {
             it = node->insert(it, lnode->begin() + 1, lnode->end());
+            it += lnode->size() - 1;
+            advance = false;
+          }
           else
+          {
             uplift.push_back(lnode);
+          }
         }
 
-        if (!removed)
+        if (advance)
           ++it;
       }
 

--- a/samples/verona/lang.h
+++ b/samples/verona/lang.h
@@ -71,6 +71,8 @@ namespace verona
     TokenDef("param", flag::lookup | flag::shadowing);
   inline constexpr auto Block =
     TokenDef("block", flag::symtab | flag::defbeforeuse);
+  inline constexpr auto TypeTest = TokenDef("typetest");
+  inline constexpr auto Cast = TokenDef("cast");
 
   // Type structure.
   inline constexpr auto Type = TokenDef("type");

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -16,8 +16,6 @@ early exit
 - breaks things, the other branch doesn't join with us
 - need all moves/drops in any continuation
 
-type test conditionals
-
 ## Key Words
 
 get rid of the `package` keyword
@@ -28,11 +26,6 @@ get rid of capabilities as keywords
 get rid of `throw` as a keyword
 - it's a type, like return, break, continue
 add `try`
-
-could allow `->` as a user defined symbol
-- allow as a function name
-- consume only the first `->` in a lambda definition
-- after `typefunc`, convert it to a symbol
 
 ## `ref` Functions
 


### PR DESCRIPTION
This allows conditionals of the form:

```
if expr
{
  x: T -> ...
}
```

Instead of `expr` being evaluated for truthiness, the lambda only executes if `expr` has a dynamic type that is a subtype of `T`.
