### PR TITLE
Removing fmt target from all

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(fmt)
 
+set_target_properties(fmt PROPERTIES EXCLUDE_FROM_ALL ON)
+
 ##############################################
 # Options
 


### PR DESCRIPTION
Projects which include Trieste currently always build `fmt` (because of how they added the target) even if it was unneeded. This fixes it so that it will only be built by projects which have it as a dependency (e.g. Verona)