### PR TITLE
switch to RE2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ include(FetchContent)
 FetchContent_Declare(
   re2
   GIT_REPOSITORY https://github.com/google/re2
-  GIT_TAG        2022-12-01
-  GIT_SHALLOW    TRUE
+  GIT_TAG 2022-12-01
+  GIT_SHALLOW TRUE
 )
 
 FetchContent_MakeAvailable(re2)
@@ -15,8 +15,8 @@ FetchContent_MakeAvailable(re2)
 FetchContent_Declare(
   cli11
   GIT_REPOSITORY https://github.com/CLIUtils/CLI11
-  GIT_TAG        b9be5b9444772324459989177108a6a65b8b2769
-  GIT_SHALLOW    TRUE
+  GIT_TAG b9be5b9444772324459989177108a6a65b8b2769
+  GIT_SHALLOW TRUE
 )
 
 FetchContent_MakeAvailable(cli11)
@@ -24,33 +24,33 @@ FetchContent_MakeAvailable(cli11)
 FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt
-  GIT_TAG        9.1.0
-  GIT_SHALLOW    TRUE
+  GIT_TAG 9.1.0
+  GIT_SHALLOW TRUE
 )
 
 FetchContent_MakeAvailable(fmt)
 
 set_target_properties(fmt PROPERTIES EXCLUDE_FROM_ALL ON)
 
-##############################################
+# #############################################
 # Options
+option(TRIESTE_BUILD_SAMPLES "Specifies whether to build the samples" ON)
 
-option( TRIESTE_BUILD_SAMPLES "Specifies whether to build the samples" ON )
+set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 
-set( CMAKE_BUILD_WITH_INSTALL_RPATH ON )
+set(RE2_BUILD_TESTING OFF)
 
-##############################################
+# #############################################
 # Create target and set properties
-
 add_library(trieste INTERFACE)
 
-#Add an alias so that library can be used inside the build tree, e.g. when testing
+# Add an alias so that library can be used inside the build tree, e.g. when testing
 add_library(trieste::trieste ALIAS trieste)
 
-#Set target properties
+# Set target properties
 target_include_directories(trieste
-    INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-              $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_compile_features(trieste INTERFACE cxx_std_20)
@@ -62,13 +62,12 @@ else()
     -Wall -Wextra -Wpedantic -Werror -Wshadow)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(trieste INTERFACE -Wmismatched-tags -fstandalone-debug)
 endif()
 
-##############################################
+# #############################################
 # Installation instructions
-
 set(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR}/dist)
 
 # Clear all existing files and folders from the install directory
@@ -81,49 +80,51 @@ install(TARGETS trieste
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)  
+)
 
-#Create a ConfigVersion.cmake file
+# Create a ConfigVersion.cmake file
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion
+  ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion
 )
 
 configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/triesteConfig.cmake.in
-    ${PROJECT_BINARY_DIR}/triesteConfig.cmake
-    INSTALL_DESTINATION
-    ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+  ${PROJECT_BINARY_DIR}/triesteConfig.cmake
+  INSTALL_DESTINATION
+  ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
 )
 
 install(EXPORT ${PROJECT_NAME}_Targets
-        FILE ${PROJECT_NAME}Targets.cmake
-        NAMESPACE ${PROJECT_NAME}::
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+  FILE ${PROJECT_NAME}Targets.cmake
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
 
 install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-              ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake) 
+  ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/trieste DESTINATION include)
 
-##############################################
-## Exporting from the build tree
+# #############################################
+# # Exporting from the build tree
 export(EXPORT ${PROJECT_NAME}_Targets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/triesteTargets.cmake
-    NAMESPACE trieste::)
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/triesteTargets.cmake
+  NAMESPACE trieste::)
 
-#Register package in the User Package Registry
+# Register package in the User Package Registry
 export(PACKAGE trieste)
 
-##############################################
-## Add samples
-if( TRIESTE_BUILD_SAMPLES )
+# #############################################
+# # Add samples
+if(TRIESTE_BUILD_SAMPLES)
   enable_testing()
+
   if(NOT MSVC)
-    ## MSVC can't build the Verona example in CI it takes too much memory.
+    # # MSVC can't build the Verona example in CI it takes too much memory.
     add_subdirectory(samples/verona)
-  endif ()
+  endif()
+
   add_subdirectory(samples/infix)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(trieste VERSION 1.0.0 LANGUAGES CXX)
 
 include(FetchContent)
 
+set(RE2_BUILD_TESTING OFF CACHE INTERNAL "Turn off RE2 tests")
+
 FetchContent_Declare(
   re2
   GIT_REPOSITORY https://github.com/google/re2
@@ -37,8 +39,6 @@ set_target_properties(fmt PROPERTIES EXCLUDE_FROM_ALL ON)
 option(TRIESTE_BUILD_SAMPLES "Specifies whether to build the samples" ON)
 
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-
-set(RE2_BUILD_TESTING OFF)
 
 # #############################################
 # Create target and set properties

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,19 @@ project(trieste VERSION 1.0.0 LANGUAGES CXX)
 include(FetchContent)
 
 FetchContent_Declare(
+  re2
+  GIT_REPOSITORY https://github.com/google/re2
+  GIT_TAG        2022-12-01
+  GIT_SHALLOW    TRUE
+)
+
+FetchContent_MakeAvailable(re2)
+
+FetchContent_Declare(
   cli11
   GIT_REPOSITORY https://github.com/CLIUtils/CLI11
   GIT_TAG        b9be5b9444772324459989177108a6a65b8b2769
+  GIT_SHALLOW    TRUE
 )
 
 FetchContent_MakeAvailable(cli11)
@@ -15,6 +25,7 @@ FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt
   GIT_TAG        9.1.0
+  GIT_SHALLOW    TRUE
 )
 
 FetchContent_MakeAvailable(fmt)

--- a/include/trieste/gen.h
+++ b/include/trieste/gen.h
@@ -6,12 +6,9 @@
 #include "xoroshiro.h"
 
 #include <functional>
-#include <regex>
 
 namespace trieste
 {
-  using sv_match = std::match_results<std::string_view::const_iterator>;
-
   using Rand = xoroshiro::p128r32;
   using Seed = uint64_t;
   using Result = uint32_t;

--- a/include/trieste/regex.h
+++ b/include/trieste/regex.h
@@ -42,7 +42,12 @@ namespace trieste
         locations.resize(matches);
 
       auto matched = regex.Match(
-        sp, 0, sp.length(), re2::RE2::ANCHOR_START, match.data(), matches);
+        sp,
+        0,
+        sp.length(),
+        re2::RE2::ANCHOR_START,
+        match.data(),
+        static_cast<int>(matches));
 
       if (!matched || (match.at(0).size() == 0))
       {

--- a/include/trieste/regex.h
+++ b/include/trieste/regex.h
@@ -1,0 +1,95 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "source.h"
+
+#include <re2/re2.h>
+
+namespace trieste
+{
+  class REMatch
+  {
+  private:
+    Source source;
+    re2::StringPiece sp;
+    std::vector<re2::StringPiece> match;
+    std::vector<Location> locations;
+    size_t matches = 0;
+
+  public:
+    REMatch(Source source, size_t max_capture = 0)
+    : source(source), sp(source->view())
+    {
+      match.resize(max_capture + 1);
+      locations.resize(max_capture + 1);
+      locations[0] = {source, 0, 1};
+    }
+
+    bool empty()
+    {
+      return sp.empty();
+    }
+
+    bool consume(const RE2& regex)
+    {
+      matches = regex.NumberOfCapturingGroups() + 1;
+
+      if (match.size() < matches)
+        match.resize(matches);
+
+      if (locations.size() < matches)
+        locations.resize(matches);
+
+      auto matched = regex.Match(
+        sp, 0, sp.length(), re2::RE2::ANCHOR_START, match.data(), matches);
+
+      if (!matched || (match.at(0).size() == 0))
+      {
+        skip(0);
+        return false;
+      }
+
+      for (size_t i = 0; i < matches; i++)
+      {
+        locations[i] = {
+          source,
+          static_cast<size_t>(match.at(i).data() - source->view().data()),
+          match.at(i).size()};
+      }
+
+      sp.remove_prefix(match.at(0).size());
+      return true;
+    }
+
+    const Location& at(size_t index = 0) const
+    {
+      if (index >= matches)
+        return locations.at(0);
+
+      return locations.at(index);
+    }
+
+    template<typename T>
+    T parse(size_t index = 0) const
+    {
+      if (index >= matches)
+        return T();
+
+      T t;
+      RE2::Arg arg(&t);
+      auto& m = match.at(index);
+      arg.Parse(m.data(), m.size());
+      return t;
+    }
+
+    void skip(size_t count = 1)
+    {
+      sp.remove_prefix(count);
+      match[0] = {};
+      locations[0] = {
+        source, static_cast<size_t>(sp.data() - source->view().data()), 1};
+      matches = 0;
+    }
+  };
+}

--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -7,7 +7,6 @@
 #include <cassert>
 #include <functional>
 #include <optional>
-#include <regex>
 
 namespace trieste
 {
@@ -134,21 +133,18 @@ namespace trieste
     {
     private:
       Token type;
-      std::regex regex;
+      RE2 regex;
 
     public:
-      RegexMatch(const Token& type, const std::string& r) : type(type)
-      {
-        regex = std::regex("^" + r + "$", std::regex_constants::optimize);
-      }
+      RegexMatch(const Token& type, const std::string& r) : type(type), regex(r)
+      {}
 
       bool match(NodeIt& it, NodeIt end, Match&) const override
       {
         if ((it == end) || ((*it)->type() != type))
           return false;
 
-        auto s = (*it)->location().view();
-        if (!std::regex_match(s.begin(), s.end(), regex))
+        if (!RE2::FullMatch((*it)->location().view(), regex))
           return false;
 
         ++it;

--- a/samples/infix/CMakeLists.txt
+++ b/samples/infix/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(infix
   )
 
 target_link_libraries(infix
+  re2::re2
   CLI11::CLI11
   trieste::trieste
   )

--- a/samples/verona/CMakeLists.txt
+++ b/samples/verona/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(verona
 
 target_link_libraries(verona
   Threads::Threads
+  re2::re2
   CLI11::CLI11
   fmt::fmt
   trieste::trieste

--- a/samples/verona/readme.md
+++ b/samples/verona/readme.md
@@ -1,7 +1,5 @@
 # Todo
 
-Switch to RE2?
-
 LLVM lowering
 - could parse LLVM literals late, allowing expr that lift to reflet and not just ident
 - `new`


### PR DESCRIPTION
This switches from the `stl` regex implementation to `RE2`. While we're no longer able to use predicates or back-references, regex parsing is significantly faster.