### PR TITLE
Fixing a bug in the well-formed check

### DIFF
--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -259,10 +259,10 @@ namespace trieste
               << fields.size() << " children, found " << node->size()
               << std::endl
               << node->location().str() << node->str() << std::endl;
-          return false;
+          ok = false;
         }
 
-        return true;
+        return ok;
       }
 
       void gen(Gen& g, size_t depth, Node node) const


### PR DESCRIPTION
I'm reasonably certain the current logic means that all well-formed checks will pass, as the final return value ignores the `ok` variable.