### PR TITLE
Adding prefix to fresh names.

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -48,9 +48,10 @@ namespace trieste
   public:
     SymtabDef() = default;
 
-    Location fresh()
+    Location fresh(const Location& prefix = {})
     {
-      return Location("$" + std::to_string(next_id++));
+      return Location(
+        std::string(prefix.view()) + "$" + std::to_string(next_id++));
     }
 
     void clear()
@@ -440,7 +441,7 @@ namespace trieste
       st->symtab_->includes.emplace_back(shared_from_this());
     }
 
-    Location fresh()
+    Location fresh(const Location& prefix = {})
     {
       // This actually returns a unique name, rather than a fresh one.
       auto p = this;
@@ -451,7 +452,7 @@ namespace trieste
       if (p->type_ != Top)
         throw std::runtime_error("No Top node");
 
-      return p->symtab_->fresh();
+      return p->symtab_->fresh(prefix);
     }
 
     Node clone()

--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -22,9 +22,9 @@ namespace trieste
   public:
     Match(Node in_node) : in_node(in_node) {}
 
-    Location fresh()
+    Location fresh(const Location& prefix = {})
     {
-      return in_node->fresh();
+      return in_node->fresh(prefix);
     }
 
     NodeRange& operator[](const Token& token)


### PR DESCRIPTION
It is often advantageous to create a unique variable with a recognisable name to aid in debugging. This PR adds an optional prefix to the `fresh()` call to make this easier.