### PR TITLE
Minor typo fix

### DIFF
--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -79,7 +79,7 @@ namespace trieste
             if (i < (types.size() - 2))
               out << ", ";
             if (i == (types.size() - 2))
-              out << "or ";
+              out << " or ";
           }
 
           out << std::endl


### PR DESCRIPTION
Fixes a minor typo in the type list error during the well-formedness check, in which the penultimate separator is attached to the penultimate item, i.e:

`one, two, threeor four`
