### PR TITLE
Exporting CMake dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,17 +37,6 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(cli11)
 
-FetchContent_Declare(
-  fmt
-  GIT_REPOSITORY https://github.com/fmtlib/fmt
-  GIT_TAG 9.1.0
-  GIT_SHALLOW TRUE
-)
-
-FetchContent_MakeAvailable(fmt)
-
-set_target_properties(fmt PROPERTIES EXCLUDE_FROM_ALL ON)
-
 # #############################################
 # Options
 option(TRIESTE_BUILD_SAMPLES "Specifies whether to build the samples" ON)
@@ -65,6 +54,13 @@ add_library(trieste::trieste ALIAS trieste)
 target_include_directories(trieste
   INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(trieste
+  INTERFACE
+  snmallocshim-static
+  re2::re2
+  CLI11::CLI11
 )
 
 target_compile_features(trieste INTERFACE cxx_std_20)
@@ -89,7 +85,7 @@ install(CODE [[
   file(REMOVE_RECURSE ${CMAKE_INSTALL_PREFIX}/.)
   ]])
 
-install(TARGETS trieste
+install(TARGETS trieste snmallocshim-static snmalloc re2 CLI11
   EXPORT ${PROJECT_NAME}_Targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/samples/infix/CMakeLists.txt
+++ b/samples/infix/CMakeLists.txt
@@ -5,9 +5,6 @@ add_executable(infix
   )
 
 target_link_libraries(infix
-  snmallocshim-static
-  re2::re2
-  CLI11::CLI11
   trieste::trieste
   )
 

--- a/samples/verona/CMakeLists.txt
+++ b/samples/verona/CMakeLists.txt
@@ -1,5 +1,16 @@
 find_package(Threads REQUIRED)
 
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt
+  GIT_TAG 9.1.0
+  GIT_SHALLOW TRUE
+)
+
+FetchContent_MakeAvailable(fmt)
+
+set_target_properties(fmt PROPERTIES EXCLUDE_FROM_ALL ON)
+
 add_executable(verona
   lang.cc
   lookup.cc
@@ -9,10 +20,7 @@ add_executable(verona
   )
 
 target_link_libraries(verona
-  snmallocshim-static
   Threads::Threads
-  re2::re2
-  CLI11::CLI11
   fmt::fmt
   trieste::trieste
   )


### PR DESCRIPTION
This minor change to the CMake configuration makes it so that `trieste` exports the targets of its dependencies in addition to its own, as well as making the dependency relationship explicit. The result of this is that projects which use `trieste` no longer need to explicitly link its dependencies, but rather can just link `trieste::trieste`, like so:

```cmake
target_link_libraries(myproject PUBLIC trieste::trieste)
```