### PR TITLE
Attempt to allow `const Node&` for creating `WFLookup` objects

### DIFF
--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -934,6 +934,7 @@ namespace trieste
       {
         const Wellformed* wf;
         Node node;
+        std::size_t index;
 
         operator Node&()
         {
@@ -942,7 +943,8 @@ namespace trieste
 
         WFLookup& operator=(Node rhs)
         {
-          node->parent()->replace(node, rhs);
+          node->parent()->replace(node->parent()->at(index), rhs);
+          node = rhs;
           return *this;
         }
 
@@ -958,7 +960,8 @@ namespace trieste
 
         WFLookup operator/(const Token& field)
         {
-          return {wf, node->at(wf->index(node->type(), field))};
+          auto i = wf->index(node->type(), field);
+          return {wf, node->at(i), i};
         }
       };
     }
@@ -984,7 +987,7 @@ namespace trieste
       auto i = wf->index(node->type(), field);
 
       if (i != std::numeric_limits<size_t>::max())
-        return {wf, node->at(i)};
+        return {wf, node->at(i), i};
     }
 
     throw std::runtime_error(
@@ -995,6 +998,6 @@ namespace trieste
   inline wf::detail::WFLookup
   operator/(const wf::Wellformed& wf, const Node& node)
   {
-    return {&wf, node};
+    return {&wf, node, 0};
   }
 }

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -933,7 +933,7 @@ namespace trieste
       struct WFLookup
       {
         const Wellformed* wf;
-        Node& node;
+        Node node;
 
         operator Node&()
         {
@@ -973,7 +973,7 @@ namespace trieste
     }
   }
 
-  inline wf::detail::WFLookup operator/(Node& node, const Token& field)
+  inline wf::detail::WFLookup operator/(const Node& node, const Token& field)
   {
     for (auto wf : wf::detail::wf_current)
     {
@@ -991,7 +991,8 @@ namespace trieste
       std::string(field.str()) + "`");
   }
 
-  inline wf::detail::WFLookup operator/(const wf::Wellformed& wf, Node& node)
+  inline wf::detail::WFLookup
+  operator/(const wf::Wellformed& wf, const Node& node)
   {
     return {&wf, node};
   }

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -940,9 +940,10 @@ namespace trieste
           return node;
         }
 
-        void operator=(Node rhs)
+        WFLookup& operator=(Node rhs)
         {
-          node->parent()->lookup_replace(node, rhs);
+          node->parent()->replace(node, rhs);
+          return *this;
         }
 
         Node& operator->()


### PR DESCRIPTION
This is my attempt at adding this feature. It addresses the problem at the cost of adding the index to the `struct`, thus allowing the `lookup_replace` call to still have access to the correct in-place `Node&` reference.