### PR TITLE
Fix compile error on xoroshiro and libcpp rand on OSX ventura

### DIFF
--- a/include/trieste/xoroshiro.h
+++ b/include/trieste/xoroshiro.h
@@ -27,7 +27,7 @@ namespace xoroshiro
       }
 
     public:
-      typedef RESULT result_type;
+      using result_type = RESULT;
 
       XorOshiro(STATE x_ = 5489, STATE y_ = 0) : x(x_), y(y_)
       {


### PR DESCRIPTION
When trying to compile Trieste on OSX Ventura, clang++ 14.1 and gnu++20, I was receiving the following compilation error:

`/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/c++/v1/__random/uniform_real_distribution.h:119:5: error: static_assert failed due to requirement '__libcpp_random_is_valid_urng<xoroshiro::detail::XorOshiro<unsigned long long, unsigned int, 55, 14, 36>, void>::value' ""
    static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
`

The relevant comment in __random/is_valid.h above the breaking static assert is:

`A class G meets the uniform random bit generator requirements if G models  
uniform_random_bit_generator, invoke_result_t<G&> is an unsigned integer type,  
and G provides a nested typedef-name result_type that denotes the same type  
as invoke_result_t<G&>.  
(In particular, reject URNGs with signed result_types; our distributions cannot  
handle such generator types.
`  

This PR fixes this issue. Using the nested `typedef RESULT result_type` in the operator overloads is technically not necessary and just satisfy my obsessive compulsive disorder (i.e. that the typedef is not entirely useless...).

My environment is:

`
clang++ --version
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
`