### PR TITLE
Issue with `Node&` allowing parent circumvention

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -28,7 +28,7 @@ namespace trieste
   }
 
   using Nodes = std::vector<Node>;
-  using NodeIt = Nodes::iterator;
+  using NodeIt = Nodes::const_iterator;
   using NodeRange = std::pair<NodeIt, NodeIt>;
   using NodeSet = std::set<Node, std::owner_less<>>;
 
@@ -167,22 +167,22 @@ namespace trieste
       location_ *= loc;
     }
 
-    auto begin()
+    NodeIt begin()
     {
       return children.begin();
     }
 
-    auto end()
+    NodeIt end()
     {
       return children.end();
     }
 
-    auto rbegin()
+    const Nodes::const_reverse_iterator rbegin()
     {
       return children.rbegin();
     }
 
-    auto rend()
+    const Nodes::const_reverse_iterator rend()
     {
       return children.rend();
     }
@@ -202,17 +202,17 @@ namespace trieste
       return children.size();
     }
 
-    Node& at(size_t index)
+    const Node& at(size_t index)
     {
       return children.at(index);
     }
 
-    Node& front()
+    const Node& front()
     {
       return children.front();
     }
 
-    Node& back()
+    const Node& back()
     {
       return children.back();
     }
@@ -459,6 +459,11 @@ namespace trieste
         node->push_back(child->clone());
 
       return node;
+    }
+
+    void replace_at(std::size_t index, Node node2 = {})
+    {
+      replace(children.at(index), node2);
     }
 
     void replace(Node node1, Node node2 = {})

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -967,7 +967,7 @@ namespace trieste
 
         WFLookup& operator=(Node rhs)
         {
-          node->parent()->replace(node->parent()->at(index), rhs);
+          node->parent()->replace_at(index, rhs);
           node = rhs;
           return *this;
         }


### PR DESCRIPTION
This PR is about closing off a fairly damaging erroneous usage of the Trieste API. As currently written, client code can write:

```cpp
node->back() = new_node;
```

Because `back()` is a `Node&`, this call will actually change the last child of the node, but circumvent the setting of the parent. The result is that the previous child still points to `node` as its parent, and the new child has a `nullptr` parent. If `node` is then subsequently deleted, the old child still has a pointer to it and this can result in a use-after-free. The new approach is to close this functionality by making these `const Node&` and also changing the iterator to be a const iterator.

To help ease issues where this functionality was needed, I've also added a `replace_at` method which provides a way of replacing a node at an index while maintaining the parent logic.