### PR TITLE
Fix error nodes.

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -655,7 +655,7 @@ namespace trieste
 
     bool errors(std::ostream& out)
     {
-      if (!get_and_reset_contains_error())
+      if (!get_and_reset_contains_error() && type_ != Error)
         return false;
 
       bool err = false;


### PR DESCRIPTION
Error node needs to be checked for explicitly as the flag is not set on error nodes.