### PR TITLE
Addressing a warning

### DIFF
--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -621,20 +621,29 @@ namespace trieste
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
       {
         auto backtrack_it = it;
-        size_t backtrack_frame;
 
         if constexpr (CapturesLeft)
+        {
+          size_t backtrack_frame;
           backtrack_frame = match.add_frame();
 
-        if (first->match(it, parent, match))
-        {
-          return match_continuation(it, parent, match);
-        }
+          if (first->match(it, parent, match))
+          {
+            return match_continuation(it, parent, match);
+          }
 
-        it = backtrack_it;
-
-        if constexpr (CapturesLeft)
+          it = backtrack_it;
           match.return_to_frame(backtrack_frame);
+        }
+        else
+        {
+          if (first->match(it, parent, match))
+          {
+            return match_continuation(it, parent, match);
+          }
+
+          it = backtrack_it;
+        }
 
         return second->match(it, parent, match) &&
           match_continuation(it, parent, match);


### PR DESCRIPTION
In some environments, an error will be emitted for set but non-use of `backtrack_frame`:

![image](https://github.com/microsoft/Trieste/assets/6894931/4a03bc1e-9d06-49e8-b4b4-8ce7679ad822)

This PR makes a small edit to the use of ConstExpr to fix this issue.