### PR TITLE
Logging in Trieste

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "token.h"
+#include "logging.h"
 
 #include <iostream>
 #include <limits>
@@ -655,7 +656,7 @@ namespace trieste
       out << ")";
     }
 
-    bool errors(std::ostream& out)
+    bool errors()
     {
       if (!get_and_reset_contains_error() && type_ != Error)
         return false;
@@ -663,12 +664,13 @@ namespace trieste
       bool err = false;
 
       for (auto& child : children)
-        err = child->errors(out) || err;
+        err = child->errors() || err;
 
       // If an error wraps another error, print only the innermost error.
       if (err || (type_ != Error))
         return err;
 
+      logging::Error out{};
       for (auto& child : children)
       {
         if (child->type() == ErrorMsg)
@@ -678,8 +680,6 @@ namespace trieste
               << child->location().str();
       }
 
-      // Trailing blank line.
-      out << std::endl;
       return true;
     }
 

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -220,12 +220,9 @@ namespace trieste
           wf::pop_front();
           ast = new_ast;
 
-          if (diag)
-          {
-            logging::Info() << "Pass " << pass->name() << ": " << count
-                      << " iterations, " << changes << " nodes rewritten."
-                      << std::endl;
-          }
+          logging::Info() << "Pass " << pass->name() << ": " << count
+                    << " iterations, " << changes << " nodes rewritten."
+                    << std::endl;
 
           if (ast->errors())
           {

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -6,6 +6,7 @@
 #include "pass.h"
 #include "regex.h"
 #include "wf.h"
+#include "logging.h"
 
 #include <CLI/CLI.hpp>
 #include <filesystem>
@@ -61,6 +62,11 @@ namespace trieste
       bool diag = false;
       build->add_flag("-d,--diagnostics", diag, "Emit diagnostics.");
 
+      if (diag)
+      {
+        logging::set_level<logging::Info>();
+      }
+ 
       bool wfcheck = false;
       build->add_flag("-w,--wf-check", wfcheck, "Check well-formedness.");
 
@@ -98,6 +104,11 @@ namespace trieste
 
       bool test_verbose = false;
       test->add_flag("-v,--verbose", test_verbose, "Verbose output");
+
+      if (test_verbose)
+      {
+        logging::set_level<logging::Trace>();
+      }
 
       size_t test_max_depth = 10;
       test->add_option(
@@ -139,21 +150,21 @@ namespace trieste
 
             if (start_pass > limits.size())
             {
-              std::cout << "Unknown pass: " << pass << std::endl;
+              logging::Error() << "Unknown pass: " << pass << std::endl;
               return -1;
             }
 
             // Build the AST, set up the symbol table, check well-formedness,
             // and move on to the next pass.
-            ast = build_ast(source, pos2 + 1, std::cout);
+            ast = build_ast(source, pos2 + 1);
             bool ok = !!ast;
             start_pass++;
 
             // Build the symbol table and check well-formedness.
             auto& wf = passes.at(start_pass - 1)->wf();
             wf::push_back(wf);
-            ok = ok && wf.build_st(ast, std::cout);
-            ok = ok && wf.check(ast, std::cout);
+            ok = ok && wf.build_st(ast);
+            ok = ok && wf.check(ast);
 
             if (!ok)
               return -1;
@@ -164,13 +175,13 @@ namespace trieste
             // parser AST well-formedness definition.
             start_pass = 1;
             end_pass = std::max(start_pass, end_pass);
-            ast = build_ast(source, pos2 + 1, std::cout);
+            ast = build_ast(source, pos2 + 1);
             bool ok = !!ast;
 
             // Build the symbol table and check well-formedness.
             wf::push_back(parser.wf());
-            ok = ok && parser.wf().build_st(ast, std::cout);
-            ok = ok && parser.wf().check(ast, std::cout);
+            ok = ok && parser.wf().build_st(ast);
+            ok = ok && parser.wf().check(ast);
 
             if (!ok)
               return -1;
@@ -182,14 +193,14 @@ namespace trieste
           if (std::filesystem::exists(path))
             ast = parser.parse(path);
           else
-            std::cout << "File not found: " << path << std::endl;
+            logging::Error() << "File not found: " << path << std::endl;
 
           wf::push_back(parser.wf());
           bool ok = bool(ast);
-          ok = ok && parser.wf().build_st(ast, std::cout);
+          ok = ok && parser.wf().build_st(ast);
 
           if (wfcheck)
-            ok = ok && parser.wf().check(ast, std::cout);
+            ok = ok && parser.wf().check(ast);
 
           if (!ok)
           {
@@ -211,12 +222,12 @@ namespace trieste
 
           if (diag)
           {
-            std::cout << "Pass " << pass->name() << ": " << count
+            logging::Info() << "Pass " << pass->name() << ": " << count
                       << " iterations, " << changes << " nodes rewritten."
                       << std::endl;
           }
 
-          if (ast->errors(std::cout))
+          if (ast->errors())
           {
             end_pass = i;
             ret = -1;
@@ -224,10 +235,10 @@ namespace trieste
 
           if (wf)
           {
-            auto ok = wf.build_st(ast, std::cout);
+            auto ok = wf.build_st(ast);
 
             if (wfcheck)
-              ok = wf.check(ast, std::cout) && ok;
+              ok = wf.check(ast) && ok;
 
             if (!ok)
             {
@@ -253,14 +264,14 @@ namespace trieste
         }
         else
         {
-          std::cout << "Could not open " << output << " for writing."
+          logging::Error() << "Could not open " << output << " for writing."
                     << std::endl;
           ret = -1;
         }
       }
       else if (*test)
       {
-        std::cout << "Testing x" << test_seed_count << ", seed: " << test_seed
+        logging::Output() << "Testing x" << test_seed_count << ", seed: " << test_seed
                   << std::endl;
 
         if (test_start_pass.empty())
@@ -284,46 +295,45 @@ namespace trieste
 
           if (!prev || !wf)
           {
-            std::cout << "Skipping pass: " << pass->name() << std::endl;
+            logging::Info() << "Skipping pass: " << pass->name() << std::endl;
             continue;
           }
 
-          std::cout << "Testing pass: " << pass->name() << std::endl;
+          logging::Info() << "Testing pass: " << pass->name() << std::endl;
           wf::push_back(prev);
           wf::push_back(wf);
 
           for (size_t seed = test_seed; seed < test_seed + test_seed_count;
                seed++)
           {
-            std::stringstream ss1;
-            std::stringstream ss2;
-
             auto ast = prev.gen(parser.generators(), seed, test_max_depth);
-            ss1 << "============" << std::endl
+            logging::Trace() << "============" << std::endl
                 << "Pass: " << pass->name() << ", seed: " << seed << std::endl
                 << "------------" << std::endl
                 << ast << "------------" << std::endl;
 
-            if (test_verbose)
-              std::cout << ss1.str();
-
             auto [new_ast, count, changes] = pass->run(ast);
-            ss2 << new_ast << "------------" << std::endl << std::endl;
+            logging::Trace() << new_ast << "------------" << std::endl << std::endl;
 
-            if (test_verbose)
-              std::cout << ss2.str();
-
-            std::stringstream ss3;
-
-            auto ok = wf.build_st(new_ast, ss3);
-            ok = wf.check(new_ast, ss3) && ok;
+            auto ok = wf.build_st(new_ast);
+            ok = wf.check(new_ast) && ok;
 
             if (!ok)
             {
-              if (!test_verbose)
-                std::cout << ss1.str() << ss2.str();
+              // Discussion Point
+              // COMMENT TO BE REMOVE BEFORE MERGE
+              // 
+              // The following is hard to do with the new log library.
+              // It previously calculated a lot of stuff which it would only use
+              // if something went wrong.  I am not sure this is a good pattern, 
+              // as it slows down testing, if there is a crash it can be rerun with the correct seed,
+              // and a higher logging level.
+              // We could even redo the whole process?
+              //
+              // if (!test_verbose)
+              //   std::cout << ss1.str() << ss2.str();
 
-              std::cout << ss3.str() << "============" << std::endl
+              logging::Error() << "============" << std::endl
                         << "Failed pass: " << pass->name() << ", seed: " << seed
                         << std::endl;
               ret = -1;

--- a/include/trieste/logging.h
+++ b/include/trieste/logging.h
@@ -1,0 +1,241 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <snmalloc/ds_core/defines.h>
+#include <sstream>
+
+namespace trieste::logging
+{
+  namespace detail
+  {
+    /**
+     * @brief Wrapper for delaying the C++ constructor of an object to
+     * allow for a manual lifetime with placement new.
+     *
+     * @tparam T - The underlying type that is being wrapped.
+     */
+    template<typename T>
+    class UnsafeInit
+    {
+      char data[sizeof(T)];
+
+    public:
+      template<typename... Args>
+      void init(Args&&... args)
+      {
+        new (data) T(std::forward<Args>(args)...);
+      }
+
+      T& get()
+      {
+        return *reinterpret_cast<T*>(data);
+      }
+
+      void destruct()
+      {
+        get().~T();
+      }
+    };
+
+    enum class LogLevel
+    {
+      None = 0,
+      Error = 1,
+      Output = 2,
+      Warn = 3,
+      Info = 4,
+      Debug = 5,
+      Trace = 6
+    };
+
+    // Used to set which level of message should be reported.
+    inline static LogLevel report_level{LogLevel::Output};
+
+    class Indent
+    {};
+    class Undent
+    {};
+  } // namespace detail
+
+  static constexpr detail::Indent Indent{};
+  static constexpr detail::Undent Undent{};
+
+  template<detail::LogLevel Level>
+  class Log
+  {
+    // Should the log actually do stuff. Decided at creation so that we can 
+    // fast path away from actually doing the work.
+    bool const print;
+
+    // The number of characters to indent by.
+    size_t indent_chars{0};
+
+    // The string stream that we are writing to.
+    // Using a local stream prevents log tearing in a concurrent setting.
+    // The UnsafeInit wrapper prevents initialisation if the log is not going to
+    // print.
+    detail::UnsafeInit<std::stringstream> strstream;
+
+    /**
+     * The following methods
+     *  - start
+     *  - append
+     *  - end
+     *  - operation
+     *  - indent
+     *  - undent
+     * all are the slow paths where logging is actually enabled.
+     * 
+     * The code is structured so these should not impact perf when logging is
+     * not going to occur.
+     */
+
+    SNMALLOC_SLOW_PATH void start()
+    {
+      strstream.init();
+      if (header_callback)
+      {
+        // Indent all lines after a header by 5 spaces.
+        indent_chars = 5;
+        // Add the header.
+        header_callback(strstream.get());
+      }
+    }
+
+    template<typename T>
+    SNMALLOC_SLOW_PATH void append(T&& t)
+    {
+      strstream.get() << std::forward<T>(t);
+    }
+
+    SNMALLOC_SLOW_PATH void end()
+    {
+      strstream.get() << std::endl;
+      dump_callback(strstream.get());
+      strstream.destruct();
+    }
+
+    SNMALLOC_SLOW_PATH void operation(std::ostream& (*f)(std::ostream&))
+    {
+      // Intercept std::endl and indent the next line.
+      if (f == std::endl<char, std::char_traits<char>>)
+        strstream.get() << std::endl << std::setw(indent_chars) << "";
+      else
+        strstream.get() << f;
+    }
+
+    SNMALLOC_SLOW_PATH void indent()
+    {
+      ++indent_chars;
+      *this << std::endl;
+    }
+
+    SNMALLOC_SLOW_PATH void undent()
+    {
+      if (indent_chars == 0)
+        throw std::runtime_error("Undent called too many times");
+      --indent_chars;
+      *this << std::endl;
+    }
+
+  public:
+    static constexpr detail::LogLevel level{Level};
+
+    // Used to add a header to each log message.
+    // For example, this could be used to start each line with a thread
+    // identifier or a timestamp.
+    inline static std::function<void(std::stringstream&)> header_callback{};
+
+    // Used to dump the string stream to a file or stdout.
+    // Defaults to stdout.
+    inline static std::function<void(std::stringstream&)> dump_callback{
+      [](std::stringstream& s) { std::cout << s.str() << std::flush; }};
+
+    // Delete copy constructor and assignment operator.
+    Log(const Log&) = delete;
+    Log& operator=(const Log&) = delete;
+
+    // Delete move constructor and assignment operator.
+    Log(Log&&) = delete;
+    Log& operator=(Log&&) = delete;
+
+    SNMALLOC_FAST_PATH Log() : print(level <= detail::report_level)
+    {
+      if (SNMALLOC_UNLIKELY(print))
+        start();
+    }
+
+    SNMALLOC_FAST_PATH Log& operator<<(std::ostream& (*f)(std::ostream&)) &
+    {
+      if (print)
+        operation(f);
+      return *this;
+    }
+
+    SNMALLOC_FAST_PATH Log& operator<<(std::ostream& (*f)(std::ostream&)) &&
+    {
+      return *this << f;
+    }
+
+    SNMALLOC_FAST_PATH Log& operator<<(detail::Indent) &
+    {
+      if (print)
+        indent();
+      return *this;
+    }
+
+    SNMALLOC_FAST_PATH Log& operator<<(detail::Indent i) &&
+    {
+      return *this << i;
+    }
+
+    SNMALLOC_FAST_PATH Log& operator<<(detail::Undent) &
+    {
+      if (print)
+        undent();
+      return *this;
+    }
+
+    SNMALLOC_FAST_PATH Log& operator<<(detail::Undent u) &&
+    {
+      return *this << u;
+    }
+
+    template<typename T>
+    SNMALLOC_FAST_PATH Log& operator<<(T&& t) &
+    {
+      if (print)
+        append(std::forward<T>(t));
+      return *this;
+    }
+
+    template<typename T>
+    SNMALLOC_FAST_PATH Log& operator<<(T&& t) &&
+    {
+      return *this << std::forward<T>(t);
+    }
+
+    SNMALLOC_FAST_PATH ~Log()
+    {
+      if (print)
+        end();
+    }
+  };
+
+  using Output = Log<detail::LogLevel::Output>;
+  using Error = Log<detail::LogLevel::Error>;
+  using Warn = Log<detail::LogLevel::Warn>;
+  using Info = Log<detail::LogLevel::Info>;
+  using Debug = Log<detail::LogLevel::Debug>;
+  using Trace = Log<detail::LogLevel::Trace>;
+
+  template <typename L>
+  inline void set_level()
+  {
+    detail::report_level = L::level;
+  }
+} // namespace trieste

--- a/include/trieste/logging.h
+++ b/include/trieste/logging.h
@@ -98,6 +98,7 @@ namespace trieste::logging
     {
       strstream.init();
       indent_chars = 0;
+      print = true;
       if (header_callback)
       {
         // Indent all lines after a header by 5 spaces.

--- a/include/trieste/logging.h
+++ b/include/trieste/logging.h
@@ -245,7 +245,7 @@ namespace trieste::logging
 
   // Pipe operators defined in the global namespace to allow for ADL.
   template<typename T, detail::LogLevel L>
-  SNMALLOC_FAST_PATH Log<L>& operator<<(Log<L>& self, T&& t)
+  SNMALLOC_FAST_PATH_INLINE Log<L>& operator<<(Log<L>& self, T&& t)
   {
     if (SNMALLOC_UNLIKELY(self.should_print()))
       self.append(std::forward<T>(t));
@@ -254,7 +254,7 @@ namespace trieste::logging
 
   // Pipe operators defined in the global namespace to allow for ADL.
   template<typename T, detail::LogLevel L>
-  SNMALLOC_FAST_PATH Log<L>& operator<<(Log<L>&& self, T&& t)
+  SNMALLOC_FAST_PATH_INLINE Log<L>& operator<<(Log<L>&& self, T&& t)
   {
     if (SNMALLOC_UNLIKELY(self.should_print()))
       self.append(std::forward<T>(t));

--- a/include/trieste/parse.h
+++ b/include/trieste/parse.h
@@ -4,6 +4,7 @@
 
 #include "ast.h"
 #include "gen.h"
+#include "logging.h"
 #include "regex.h"
 #include "wf.h"
 

--- a/include/trieste/regex.h
+++ b/include/trieste/regex.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "logging.h"
 #include "source.h"
 
 #include <re2/re2.h>
@@ -115,7 +116,7 @@ namespace trieste
     }
   };
 
-  inline Node build_ast(Source source, size_t pos, std::ostream& out)
+  inline Node build_ast(Source source, size_t pos)
   {
     auto hd = RE2("[[:space:]]*\\([[:space:]]*([^[:space:]\\(\\)]*)");
     auto st = RE2("[[:space:]]*\\{[^\\}]*\\}");
@@ -135,8 +136,9 @@ namespace trieste
       if (!re_iterator.consume(hd, re_match))
       {
         auto loc = re_iterator.current();
-        out << loc.origin_linecol() << ": expected node" << std::endl
-            << loc.str() << std::endl;
+        logging::Error() << loc.origin_linecol() << ": expected node"
+                         << std::endl
+                         << loc.str() << std::endl;
         return {};
       }
 
@@ -146,8 +148,9 @@ namespace trieste
 
       if (type == Invalid)
       {
-        out << type_loc.origin_linecol() << ": unknown type" << std::endl
-            << type_loc.str() << std::endl;
+        logging::Error() << type_loc.origin_linecol() << ": unknown type"
+                         << std::endl
+                         << type_loc.str() << std::endl;
         return {};
       }
 
@@ -189,8 +192,8 @@ namespace trieste
 
     // We never finished the AST, so it's an error.
     auto loc = re_iterator.current();
-    out << loc.origin_linecol() << ": incomplete AST" << std::endl
-        << loc.str() << std::endl;
+    logging::Error() << loc.origin_linecol() << ": incomplete AST" << std::endl
+                     << loc.str() << std::endl;
     return {};
   }
 }


### PR DESCRIPTION
This PR creates a logging/tracing library for Trieste to use.  This can then be used by downstream projects such as rego-cpp and verona. The intent is to reduce the cost of checking whether log should be generated.

There is a pure C++ approach to using the library
```C++
   trieste::logging::Info() << "Hello " << 5;
```
that will output a log message if the `Info` level should be printed.  The messages are output on destruction of the `Log` object, so that there is no tearing in a concurrent setting.

The log object can also be a local variable to allow more complex messages to be constructed.
```C++
trieste::logging::Info out;
out << "Hello" << trieste::logging::Indent;
for (int i = 0; i < 10 ; i++)
  out << "i = " << i << std::endl; 
out << trieste::logging::Undent;
out << "Goodbye.";
```
which will print the following at the end of `out`'s scope:
```
Hello
 i = 0
 i = 1
 i = 2
Goodbye.
```
Here we use the `Indent` and `Undent` line terminators that alter the indentation level of the following lines. 


The implementation tries very hard to force the compiler to move the logging off the fast path.  For example:
```C++
  size_t fib(size_t i)
  {
    if (i < 2)
    {
      return i;
    }

    logging::Info() << "fib(" << i << ") = ? " << std::endl;

    auto result = fib(i - 1) + fib(i - 2);
    logging::Info() << "fib(" << i << ") = " << result << std::endl;
    return result;
  }
```
generates
```asm
000000000002bf30 <infix::fib(unsigned long)>:
   2bf30:       53                      push   %rbx
   2bf31:       48 81 ec b0 01 00 00    sub    $0x1b0,%rsp
   2bf38:       48 89 f8                mov    %rdi,%rax
   2bf3b:       48 89 7c 24 08          mov    %rdi,0x8(%rsp)
   2bf40:       48 83 ff 02             cmp    $0x2,%rdi
   2bf44:       72 4b                   jb     2bf91 <infix::fib(unsigned long)+0x61>
   2bf46:       c6 44 24 18 00          movb   $0x0,0x18(%rsp)
   2bf4b:       80 3d f6 cf 0e 00 01    cmpb   $0x1,0xecff6(%rip)        # 118f48 <trieste::logging::detail::report_level>
   2bf52:       74 46                   je     2bf9a <infix::fib(unsigned long)+0x6a>
   2bf54:       48 8b 7c 24 08          mov    0x8(%rsp),%rdi
   2bf59:       48 ff cf                dec    %rdi
   2bf5c:       e8 cf ff ff ff          call   2bf30 <infix::fib(unsigned long)>
   2bf61:       48 89 c3                mov    %rax,%rbx
   2bf64:       48 8b 7c 24 08          mov    0x8(%rsp),%rdi
   2bf69:       48 83 c7 fe             add    $0xfffffffffffffffe,%rdi
   2bf6d:       e8 be ff ff ff          call   2bf30 <infix::fib(unsigned long)>
   2bf72:       48 01 d8                add    %rbx,%rax
   2bf75:       48 89 44 24 10          mov    %rax,0x10(%rsp)
   2bf7a:       c6 44 24 18 00          movb   $0x0,0x18(%rsp)
   2bf7f:       80 3d c2 cf 0e 00 01    cmpb   $0x1,0xecfc2(%rip)        # 118f48 <trieste::logging::detail::report_level>
   2bf86:       0f 84 98 00 00 00       je     2c024 <infix::fib(unsigned long)+0xf4>
   2bf8c:       48 8b 44 24 10          mov    0x10(%rsp),%rax
   2bf91:       48 81 c4 b0 01 00 00    add    $0x1b0,%rsp
   2bf98:       5b                      pop    %rbx
   2bf99:       c3                      ret    
   2bf9a:       48 8d 7c 24 18          lea    0x18(%rsp),%rdi
   2bf9f:       e8 4c 1e 04 00          call   6ddf0 <trieste::logging::Log<(trieste::logging::detail::LogLevel)4>::start()>
   ...
```

There is additionally a macro that can be enables `LOG` with defining `TRIESTE_EXPOSE_LOG_MACRO`.  This uses macro tricks such that
```C++
  LOG(Info) << "Hello " << "World" << fib(23);
```
will only evaluated `fib(23)` if the `Info` level should be printed.  This is not the case for the pure C++ version:
```C++
  trieste::logging::Info() << "Hello " << "World" << fib(23);
```
