### PR TITLE
Fix for https://github.com/actions/runner-images/issues/8659

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -18,7 +18,7 @@ jobs:
         include:
         - platform: "ubuntu-latest"
           compiler: "clang"
-          cmake_options: "-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_FLAGS=-stdlib=libc++"
+          cmake_options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15"
           generator: "-G Ninja"
           dependencies: "sudo apt install ninja-build"
     


### PR DESCRIPTION
This issue is causing the Clang build to fail. This moves the CI to using clang++-15 to address the issue:

https://github.com/actions/runner-images/issues/8659