### PR TITLE
Fix for "assuming cast" compiler error on comparison to std::endl.

### DIFF
--- a/include/trieste/logging.h
+++ b/include/trieste/logging.h
@@ -156,10 +156,11 @@ namespace trieste::logging
       strstream.destruct();
     }
 
-    SNMALLOC_SLOW_PATH void operation(std::ostream& (*f)(std::ostream&))
+    SNMALLOC_SLOW_PATH void operation(decltype(std::endl<char, std::char_traits<char>>) f)
     {
+      auto endl_func = std::endl<char, std::char_traits<char>>;
       // Intercept std::endl and indent the next line.
-      if (f == std::endl<char, std::char_traits<char>>)
+      if (f == endl_func)
         strstream.get() << std::endl << std::setw(indent_chars) << "";
       else
         strstream.get() << f;


### PR DESCRIPTION
On some platforms (notably musllinux) the comparison changed in the PR causes an compiler error about assuming a cast on f. The committed change fixes that compiler error without any change in functionality.