### PR TITLE
Adding a JSON parser based on Trieste

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -72,6 +72,7 @@ IndentCaseLabels: true
 IndentPPDirectives: AfterHash
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertNewlineAtEOF: true
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -18,10 +18,18 @@ jobs:
         include:
         - platform: "ubuntu-latest"
           compiler: "clang"
-          cmake_options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_BUILD_PARSER_TESTS=1"
           generator: "-G Ninja"
           dependencies: "sudo apt install ninja-build"
-    
+
+        - platform: "windows-latest"
+          build-type: "Release"
+          cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
+        
+        - platform: "macos-latest"
+          build-type: "Release"
+          cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
+
         exclude:
         # Mac is already using clang.
         - platform: "macos-latest"
@@ -42,7 +50,7 @@ jobs:
       run: ${{ matrix.dependencies }}
       
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.generator}} ${{matrix.standard}} ${{matrix.cmake_options}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.generator}} ${{matrix.standard}} ${{matrix.cmake-options}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(trieste VERSION 1.0.0 LANGUAGES CXX)
 # #############################################
 # Options
 option(TRIESTE_BUILD_SAMPLES "Specifies whether to build the samples" ON)
+option(TRIESTE_BUILD_PARSERS "Specifies whether to build the parsers" ON)
+option(TRIESTE_BUILD_PARSER_TESTS "Specifies whether to build the parser tests" OFF)
 option(TRIESTE_USE_CXX17 "Specifies whether to target the C++17 standard" OFF)
 
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
@@ -95,14 +97,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(trieste INTERFACE -Wmismatched-tags -fstandalone-debug)
 endif()
 
-# #############################################
-# Installation instructions
-set(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR}/dist)
-
 # Clear all existing files and folders from the install directory
 install(CODE [[
   file(REMOVE_RECURSE ${CMAKE_INSTALL_PREFIX}/.)
   ]])
+
+# #############################################
+# Installation instructions
+set(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR}/dist)
 
 install(TARGETS trieste snmallocshim-static snmalloc re2 CLI11
   EXPORT ${PROJECT_NAME}_Targets
@@ -150,4 +152,10 @@ export(PACKAGE trieste)
 if(TRIESTE_BUILD_SAMPLES)
   enable_testing()
   add_subdirectory(samples/infix)
+endif()
+
+# #############################################
+# # Add parsers
+if(TRIESTE_BUILD_PARSERS)
+  add_subdirectory(parsers)
 endif()

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -660,16 +660,24 @@ namespace trieste
      */
     void get_errors(Nodes& errors)
     {
-      if (!get_and_reset_contains_error())
-      {
-        // Only add Error nodes that do not contain further Error nodes.
-        if (type_ == Error)
-          errors.push_back(shared_from_this());
-        return;
-      }
+      std::vector<Node> stack;
+      stack.push_back(shared_from_this());
 
-      for (auto& child : children)
-        child->get_errors(errors);
+      while(!stack.empty()){
+        Node current = stack.back();
+        stack.pop_back();
+
+        if (!current->get_and_reset_contains_error())
+        {
+          // Only add Error nodes that do not contain further Error nodes.
+          if (current->type_ == Error)
+            errors.push_back(current);
+
+          continue;
+        }
+
+        stack.insert(stack.end(), current->children.begin(), current->children.end());
+      }
     }
 
     bool get_and_reset_contains_error()

--- a/include/trieste/utf8.h
+++ b/include/trieste/utf8.h
@@ -1,0 +1,563 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <string>
+#include <string_view>
+
+namespace trieste
+{
+  namespace utf8
+  {
+    enum class DetectResult
+    {
+      None,
+      BigEndian,
+      LittleEndian
+    };
+
+    const uint8_t MaskX = 0b11000000;
+    const uint8_t Mask1 = 0b10000000;
+    const uint8_t Mask2 = 0b11100000;
+    const uint8_t Mask3 = 0b11110000;
+    const uint8_t Mask4 = 0b11111000;
+
+    const uint8_t MarkX = 0b10000000;
+    const uint8_t Mark1 = 0b00000000;
+    const uint8_t Mark2 = 0b11000000;
+    const uint8_t Mark3 = 0b11100000;
+    const uint8_t Mark4 = 0b11110000;
+
+    const uint8_t ValueX = 0b00111111;
+    const uint8_t Value1 = 0b01111111;
+    const uint8_t Value2 = 0b00011111;
+    const uint8_t Value3 = 0b00001111;
+    const uint8_t Value4 = 0b00000111;
+
+    const uint32_t Max1 = 0x007F;
+    const uint32_t Max2 = 0x07FF;
+    const uint32_t Max3 = 0xFFFF;
+    const uint32_t Max4 = 0x10FFFF;
+
+    const std::size_t ShiftX = 6;
+
+    const uint32_t Bad = 0xFFFD;
+
+    inline std::ostream& write_rune(std::ostream& os, uint32_t value)
+    {
+      if (value <= Max1)
+      {
+        return os << static_cast<char>(Mark1 | value);
+      }
+
+      if (value <= Max2)
+      {
+        char c1 = static_cast<char>((value & ValueX) | MarkX);
+        value >>= ShiftX;
+        char c0 = static_cast<char>(Mark2 | value);
+        return os << c0 << c1;
+      }
+
+      if (value <= Max3)
+      {
+        char c2 = static_cast<char>((value & ValueX) | MarkX);
+        value >>= ShiftX;
+        char c1 = static_cast<char>((value & ValueX) | MarkX);
+        value >>= ShiftX;
+        char c0 = static_cast<char>(Mark3 | value);
+        return os << c0 << c1 << c2;
+      }
+
+      if (value <= Max4)
+      {
+        char c3 = static_cast<char>((value & ValueX) | MarkX);
+        value >>= ShiftX;
+        char c2 = static_cast<char>((value & ValueX) | MarkX);
+        value >>= ShiftX;
+        char c1 = static_cast<char>((value & ValueX) | MarkX);
+        value >>= ShiftX;
+        char c0 = static_cast<char>(Mark4 | value);
+        return os << c0 << c1 << c2 << c3;
+      }
+
+      // bad
+      return write_rune(os, Bad);
+    }
+
+    struct rune
+    {
+      rune(uint32_t v) : value(v) {}
+      std::size_t size()
+      {
+        if (value <= Max1)
+        {
+          return 1;
+        }
+
+        if (value <= Max2)
+        {
+          return 2;
+        }
+
+        if (value <= Max3)
+        {
+          return 3;
+        }
+
+        if (value <= Max4)
+        {
+          return 4;
+        }
+
+        return 3;
+      }
+
+      std::string to_utf8()
+      {
+        std::ostringstream os;
+        write_rune(os, value);
+        return os.str();
+      }
+
+      uint32_t value;
+    };
+
+    using runestring = std::basic_string<uint32_t>;
+    using runestring_view = std::basic_string_view<uint32_t>;
+
+    inline std::pair<rune, std::string_view>
+    utf8_to_rune(const std::string_view& utf8, bool unescape_unicode)
+    {
+      uint8_t c0 = static_cast<uint8_t>(utf8[0]);
+      if (c0 == '\\' && unescape_unicode)
+      {
+        if (utf8.size() >= 3 && utf8[1] == 'x')
+        {
+          std::string hex = std::string(utf8.substr(2, 2));
+          return {std::stoul(hex, nullptr, 16), utf8.substr(0, 4)};
+        }
+
+        if (utf8.size() >= 5 && utf8[1] == 'u')
+        {
+          std::string hex = std::string(utf8.substr(2, 4));
+          return {std::stoul(hex, nullptr, 16), utf8.substr(0, 6)};
+        }
+
+        if (utf8.size() >= 9 && utf8[1] == 'U')
+        {
+          std::string hex = std::string(utf8.substr(2, 8));
+          return {std::stoul(hex, nullptr, 16), utf8.substr(0, 10)};
+        }
+
+        return {utf8[0], utf8.substr(0, 1)};
+      }
+
+      if ((c0 & Mask1) == Mark1)
+      {
+        return {c0 & Value1, utf8.substr(0, 1)};
+      }
+
+      if ((c0 & Mask2) == Mark2 && utf8.size() >= 2)
+      {
+        uint8_t c1 = static_cast<uint8_t>(utf8[1]);
+        if ((c1 & MaskX) == MarkX)
+        {
+          uint32_t value = c0 & Value2;
+          value = (value << ShiftX) | (c1 & ValueX);
+          return {value, utf8.substr(0, 2)};
+        }
+      }
+      else if ((c0 & Mask3) == Mark3 && utf8.size() >= 3)
+      {
+        uint8_t c1 = static_cast<uint8_t>(utf8[1]);
+        uint8_t c2 = static_cast<uint8_t>(utf8[2]);
+        if ((c1 & MaskX) == MarkX && (c2 & MaskX) == MarkX)
+        {
+          uint32_t value = c0 & Value3;
+          value = (value << ShiftX) | (c1 & ValueX);
+          value = (value << ShiftX) | (c2 & ValueX);
+          return {value, utf8.substr(0, 3)};
+        }
+      }
+      else if ((c0 & Mask4) == Mark4 && utf8.size() >= 4)
+      {
+        uint8_t c1 = static_cast<uint8_t>(utf8[1]);
+        uint8_t c2 = static_cast<uint8_t>(utf8[2]);
+        uint8_t c3 = static_cast<uint8_t>(utf8[3]);
+        if (
+          (c1 & MaskX) == MarkX && (c2 & MaskX) == MarkX &&
+          (c3 & MaskX) == MarkX)
+        {
+          uint32_t value = c0 & Value4;
+          value = (value << ShiftX) | (c1 & ValueX);
+          value = (value << ShiftX) | (c2 & ValueX);
+          value = (value << ShiftX) | (c3 & ValueX);
+          return {value, utf8.substr(0, 4)};
+        }
+      }
+
+      // bad
+      return {Bad, utf8.substr(0, 1)};
+    }
+
+    inline std::ostream& operator<<(std::ostream& os, const rune& r)
+    {
+      return write_rune(os, r.value);
+    }
+
+    inline std::ostream& operator<<(std::ostream& os, const runestring_view& runes)
+    {
+      for (uint32_t r : runes)
+      {
+        os << rune(r);
+      }
+
+      return os;
+    }
+
+    inline std::ostream& operator<<(std::ostream& os, const runestring& runes)
+    {
+      for (uint32_t r : runes)
+      {
+        os << rune(r);
+      }
+
+      return os;
+    }
+
+    inline runestring utf8_to_runestring(
+      const std::string_view& input, bool unescape_hexunicode = false)
+    {
+      runestring runes;
+      runes.reserve(input.size());
+      std::size_t pos = 0;
+      while (pos < input.size())
+      {
+        auto [r, s] =
+          utf8_to_rune(input.substr(pos), unescape_hexunicode);
+        runes.push_back(r.value);
+        pos += s.size();
+      }
+
+      return runes;
+    }
+
+    inline bool detect_utf8(const std::string& contents)
+    {
+      auto runes = utf8_to_runestring(contents, false);
+      return !std::any_of(
+        runes.begin(), runes.end(), [](uint32_t r) { return r == Bad; });
+    }
+
+    inline DetectResult detect_utf16(const std::string& contents)
+    {
+      const std::set<uint16_t> big_endian = {
+        0x002C, // comma
+        0x0022, // double quote
+        0x0028, // left parenthesis
+        0x0029, // right parenthesis
+        0x005B, // left square bracket
+        0x005D, // right square bracket
+        0x007B, // left curly bracket
+        0x007D, // right curly bracket,
+        0x003A, // colon
+        0x003B, // semicolon
+        0x0020, // space
+        0x000A, // newline
+      };
+
+      const std::set<uint16_t> little_endian = {
+        0x2C00, // comma
+        0x2200, // double quote
+        0x2800, // left parenthesis
+        0x2900, // right parenthesis
+        0x5B00, // left square bracket
+        0x5D00, // right square bracket
+        0x7B00, // left curly bracket
+        0x7D00, // right curly bracket,
+        0x3A00, // colon
+        0x3B00, // semicolon
+        0x2000, // space
+        0x0A00, // newline
+      };
+
+      if (contents.size() % 2 != 0)
+      {
+        return DetectResult::None;
+      }
+
+      std::size_t le_counts = 0;
+      std::size_t be_counts = 0;
+      for (std::size_t i = 0; i < contents.size(); i += 2)
+      {
+        uint8_t b0 = static_cast<uint8_t>(contents[i]);
+        uint8_t b1 = static_cast<uint8_t>(contents[i + 1]);
+        uint16_t value = (b0 << 8) | b1;
+        if (little_endian.find(value) != little_endian.end())
+        {
+          le_counts++;
+        }
+        if (big_endian.find(value) != big_endian.end())
+        {
+          be_counts++;
+        }
+      }
+
+      if (le_counts > be_counts)
+      {
+        return DetectResult::LittleEndian;
+      }
+      if (be_counts > le_counts)
+      {
+        return DetectResult::BigEndian;
+      }
+      return DetectResult::None;
+    }
+
+    inline DetectResult detect_utf32(const std::string& contents)
+    {
+      const std::set<uint32_t> big_endian = {
+        0x0000002C, // comma
+        0x00000022, // double quote
+        0x00000028, // left parenthesis
+        0x00000029, // right parenthesis
+        0x0000005B, // left square bracket
+        0x0000005D, // right square bracket
+        0x0000007B, // left curly bracket
+        0x0000007D, // right curly bracket,
+        0x0000003A, // colon
+        0x0000003B, // semicolon
+        0x00000020, // space
+        0x0000000A, // newline
+      };
+
+      const std::set<uint32_t> little_endian = {
+        0x2C000000, // comma
+        0x22000000, // double quote
+        0x28000000, // left parenthesis
+        0x29000000, // right parenthesis
+        0x5B000000, // left square bracket
+        0x5D000000, // right square bracket
+        0x7B000000, // left curly bracket
+        0x7D000000, // right curly bracket,
+        0x3A000000, // colon
+        0x3B000000, // semicolon
+        0x20000000, // space
+        0x0A000000, // newline
+      };
+
+      if (contents.size() % 4 != 0)
+      {
+        return DetectResult::None;
+      }
+
+      std::size_t le_counts = 0;
+      std::size_t be_counts = 0;
+      for (std::size_t i = 0; i < contents.size(); i += 4)
+      {
+        uint8_t b0 = static_cast<uint8_t>(contents[i]);
+        uint8_t b1 = static_cast<uint8_t>(contents[i + 1]);
+        uint8_t b2 = static_cast<uint8_t>(contents[i + 2]);
+        uint8_t b3 = static_cast<uint8_t>(contents[i + 3]);
+        uint32_t value = (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
+        if (little_endian.find(value) != little_endian.end())
+        {
+          le_counts++;
+        }
+        if (big_endian.find(value) != big_endian.end())
+        {
+          be_counts++;
+        }
+      }
+
+      if (le_counts > be_counts)
+      {
+        return DetectResult::LittleEndian;
+      }
+      if (be_counts > le_counts)
+      {
+        return DetectResult::BigEndian;
+      }
+      return DetectResult::None;
+    }
+
+    inline std::string read_utf16_be(const std::string& contents)
+    {
+      std::ostringstream result;
+      for (std::size_t i = 0; i < contents.size(); i += 2)
+      {
+        uint8_t b0 = static_cast<uint8_t>(contents[i]);
+        uint8_t b1 = static_cast<uint8_t>(contents[i + 1]);
+        result << rune((b0 << 8) | b1);
+      }
+
+      return result.str();
+    }
+
+    inline std::string read_utf16_le(const std::string& contents)
+    {
+      std::ostringstream result;
+      for (std::size_t i = 0; i < contents.size(); i += 2)
+      {
+        uint8_t b1 = static_cast<uint8_t>(contents[i]);
+        uint8_t b0 = static_cast<uint8_t>(contents[i + 1]);
+        result << rune((b0 << 8) | b1);
+      }
+
+      return result.str();
+    }
+
+    inline std::string read_utf32_be(const std::string& contents)
+    {
+      std::ostringstream result;
+      for (std::size_t i = 0; i < contents.size(); i += 4)
+      {
+        uint8_t b0 = static_cast<uint8_t>(contents[i]);
+        uint8_t b1 = static_cast<uint8_t>(contents[i + 1]);
+        uint8_t b2 = static_cast<uint8_t>(contents[i + 2]);
+        uint8_t b3 = static_cast<uint8_t>(contents[i + 3]);
+        result << rune((b0 << 24) | (b1 << 16) | (b2 << 8) | b3);
+      }
+      return result.str();
+    }
+
+    inline std::string read_utf32_le(const std::string& contents)
+    {
+      std::ostringstream result;
+      for (std::size_t i = 0; i < contents.size(); i += 4)
+      {
+        uint8_t b3 = static_cast<uint8_t>(contents[i]);
+        uint8_t b2 = static_cast<uint8_t>(contents[i + 1]);
+        uint8_t b1 = static_cast<uint8_t>(contents[i + 2]);
+        uint8_t b0 = static_cast<uint8_t>(contents[i + 3]);
+        result << rune((b0 << 24) | (b1 << 16) | (b2 << 8) | b3);
+      }
+      return result.str();
+    }
+
+    inline std::string sanitize_utf8(const std::string& input)
+    {
+      std::ostringstream os;
+      auto runes = utf8_to_runestring(input);
+      for (uint32_t r : runes)
+      {
+        os << rune(r);
+      }
+      return os.str();
+    }
+
+    inline std::string unescape_hexunicode(const std::string_view& input)
+    {
+      std::ostringstream os;
+      std::size_t pos = 0;
+      while (pos < input.size())
+      {
+        if (input[pos] == '\\')
+        {
+          auto [r, s] = utf8_to_rune(input.substr(pos), true);
+          os << r;
+          pos += s.size();
+        }
+        else
+        {
+          os << input[pos];
+          pos++;
+        }
+      }
+
+      return os.str();
+    }
+
+    inline std::string read_to_end(const std::filesystem::path& path, bool autodetect = false)
+    {
+      std::ifstream fs(path, std::ios::binary);
+
+      // read as raw bytes
+      std::stringstream ss;
+      ss << fs.rdbuf();
+      std::string contents = ss.str();
+
+      if (contents.size() >= 2)
+      {
+        uint8_t bom[4] = {
+          static_cast<uint8_t>(contents[0]),
+          static_cast<uint8_t>(contents[1]),
+          0,
+          0,
+        };
+        if (contents.size() >= 3)
+        {
+          bom[2] = static_cast<uint8_t>(contents[2]);
+        }
+        if (contents.size() >= 4)
+        {
+          bom[3] = static_cast<uint8_t>(contents[3]);
+        }
+
+        if (bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF)
+        {
+          // remove BOM
+          contents = contents.substr(3);
+          return contents;
+        }
+
+        if (bom[0] == 0xFF && bom[1] == 0xFE)
+        {
+          if (bom[2] == 0x00 && bom[3] == 0x00)
+          {
+            return read_utf32_le(contents.substr(4));
+          }
+
+          return read_utf16_le(contents.substr(2));
+        }
+
+        if (
+          bom[0] == 0x00 && bom[1] == 0x00 && bom[2] == 0xFE && bom[3] == 0xFF)
+        {
+          return read_utf32_be(contents.substr(4));
+        }
+
+        if (bom[0] == 0xFE && bom[1] == 0xFF)
+        {
+          return read_utf16_be(contents.substr(2));
+        }
+      }
+
+      if (!autodetect)
+      {
+        return contents;
+      }
+
+      if (detect_utf8(contents))
+      {
+        return sanitize_utf8(contents);
+      }
+
+      switch (detect_utf16(contents))
+      {
+        case DetectResult::BigEndian:
+          return read_utf16_be(contents);
+        case DetectResult::LittleEndian:
+          return read_utf16_le(contents);
+        default:
+          break;
+      }
+
+      switch (detect_utf32(contents))
+      {
+        case DetectResult::BigEndian:
+          return read_utf32_be(contents);
+        case DetectResult::LittleEndian:
+          return read_utf32_le(contents);
+        default:
+          break;
+      }
+
+      return sanitize_utf8(contents);
+    }
+  }
+}

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -644,19 +644,26 @@ namespace trieste
         if (node == Error)
           return true;
 
-        node->clear_symbols();
+        std::vector<Node> stack;
+        stack.push_back(node);
 
         bool ok = true;
-        auto find = shapes.find(node->type());
+        while(!stack.empty()){
+          Node current = stack.back();
+          stack.pop_back();        
 
-        if (find != shapes.end())
-        {
-          ok = std::visit(
-            [&](auto& shape) { return shape.build_st(node); }, find->second);
+          current->clear_symbols();
+
+          auto find = shapes.find(current->type());
+
+          if (find != shapes.end())
+          {
+            ok = std::visit(
+              [&](auto& shape) { return shape.build_st(current); }, find->second) && ok;
+          }
+
+          stack.insert(stack.end(), current->begin(), current->end());
         }
-
-        for (auto& child : *node)
-          ok = build_st(child) && ok;
 
         return ok;
       }

--- a/parsers/CMakeLists.txt
+++ b/parsers/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_subdirectory(json)
+
+if(TRIESTE_BUILD_PARSER_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+
+    if(NOT IS_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/JSONTestSuite)
+    execute_process(COMMAND ${GIT_EXECUTABLE} clone --depth=1 https://github.com/nst/JSONTestSuite
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                    OUTPUT_QUIET)
+    endif()
+endif()

--- a/parsers/include/trieste/json.h
+++ b/parsers/include/trieste/json.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "trieste/token.h"
+#include "trieste/trieste.h"
+
+namespace trieste
+{
+  namespace json
+  {
+    using namespace wf::ops;
+
+    inline const auto Value = TokenDef("json-value");
+    inline const auto Object = TokenDef("json-object");
+    inline const auto Array = TokenDef("json-array");
+    inline const auto String = TokenDef("json-string");
+    inline const auto Number = TokenDef("json-number");
+    inline const auto True = TokenDef("json-true");
+    inline const auto False = TokenDef("json-false");
+    inline const auto Null = TokenDef("json-null");
+    inline const auto Member = TokenDef("json-member");
+    inline const auto ErrorSeq = TokenDef("json-errorseq");
+    inline const auto Comma = TokenDef("json-comma");
+    inline const auto Colon = TokenDef("json-colon");
+    inline const auto Lhs = TokenDef("json-lhs");
+    inline const auto Rhs = TokenDef("json-rhs");
+
+    // groups
+    inline const auto ArrayGroup = TokenDef("json-array-group");
+    inline const auto ObjectGroup = TokenDef("json-object-group");
+
+    inline const auto wf_parse_tokens =
+      Object | Array | String | Number | True | False | Null | Comma | Colon;
+
+    // clang-format off
+  inline const auto wf_parse =
+    (Top <<= File)
+    | (File <<= Group++)
+    | (Value <<= Group)
+    | (Array <<= Group)
+    | (Object <<= Group)
+    | (Member <<= Group)
+    | (Group <<= wf_parse_tokens++)
+    ;
+    // clang-format on
+
+    inline const auto wf_value_tokens =
+      Object | Array | String | Number | True | False | Null;
+
+    // clang-format off
+  inline const auto wf_groups =
+    (Top <<= wf_value_tokens)
+    | (Object <<= ObjectGroup)
+    | (Array <<= ArrayGroup)
+    | (ObjectGroup <<= (wf_value_tokens | Colon | Comma)++)
+    | (ArrayGroup <<= (wf_value_tokens | Comma)++)
+    ;
+    // clang-format on
+
+    // clang-format off
+  inline const auto wf_structure =
+    (Top <<= wf_value_tokens)
+    | (Object <<= Member++)
+    | (Member <<= String * (Value >>= wf_value_tokens))
+    | (Array <<= wf_value_tokens++)
+    ;
+    // clang-format on
+
+    inline auto err(Node node, const std::string& msg)
+    {
+      return Error << (ErrorMsg ^ msg) << (ErrorAst << node->clone());
+    }
+
+    inline Node err(const NodeRange& r, const std::string& msg)
+    {
+      return Error << (ErrorMsg ^ msg) << (ErrorAst << r);
+    }
+
+    inline auto err(const std::string& msg)
+    {
+      return Error << (ErrorMsg ^ msg);
+    }
+
+    Parse parser();
+    std::vector<Pass> passes();
+
+    class JSONEmitter
+    {
+    public:
+      JSONEmitter(bool prettyprint = false, const std::string& indent = "  ");
+
+      void emit(std::ostream& os, const Node& value);
+
+    private:
+      void emit_value(
+        std::ostream& os, const std::string& indent, const Node& value);
+      void emit_object(
+        std::ostream& os, const std::string& indent, const Node& value);
+      void emit_array(
+        std::ostream& os, const std::string& indent, const Node& value);
+
+      bool m_prettyprint;
+      std::string m_indent;
+    };
+
+    class JSONReader
+    {
+    public:
+      JSONReader(const std::filesystem::path& path);
+      JSONReader(const std::string& json);
+      JSONReader(const Source& source);
+
+      void read();
+
+      const Node& element() const;
+      bool has_errors() const;
+      std::string error_message() const;
+
+      JSONReader& debug_enabled(bool value);
+      bool debug_enabled() const;
+
+      JSONReader& debug_path(const std::filesystem::path& path);
+      const std::filesystem::path& debug_path() const;
+
+      JSONReader& well_formed_checks_enabled(bool value);
+      bool well_formed_checks_enabled() const;
+
+    private:
+      Source m_source;
+      Node m_element;
+      bool m_debug_enabled;
+      std::filesystem::path m_debug_path;
+      bool m_well_formed_checks_enabled;
+    };
+  }
+}

--- a/parsers/json/CMakeLists.txt
+++ b/parsers/json/CMakeLists.txt
@@ -1,0 +1,46 @@
+set( SOURCES
+parse.cc
+json.cc
+emitter.cc
+reader.cc
+)
+
+add_library(json STATIC ${SOURCES})
+
+add_library(trieste::json ALIAS json)
+
+target_link_libraries(json
+  PUBLIC
+    trieste::trieste
+)
+
+if(MSVC)
+  target_compile_options(json PUBLIC "/Zc:__cplusplus")
+  target_compile_definitions(json PUBLIC "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING")
+endif()
+
+if(TRIESTE_USE_CXX17)
+  target_compile_features(json PUBLIC cxx_std_17)
+  target_compile_definitions(json PUBLIC TRIESTE_USE_CXX17)
+else()
+  target_compile_features(json PUBLIC cxx_std_20)
+endif()
+
+target_include_directories( json
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/trieste>
+)
+
+install(TARGETS json
+  EXPORT ${PROJECT_NAME}_Targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../include/trieste/json.h DESTINATION include/trieste)

--- a/parsers/json/emitter.cc
+++ b/parsers/json/emitter.cc
@@ -1,0 +1,134 @@
+#include "json.h"
+
+namespace trieste::json
+{
+  JSONEmitter::JSONEmitter(bool prettyprint, const std::string& indent)
+  : m_prettyprint(prettyprint), m_indent(indent)
+  {}
+
+  void JSONEmitter::emit_object(
+    std::ostream& os, const std::string& indent, const Node& object)
+  {
+    if (object->empty())
+    {
+      os << "{}";
+      return;
+    }
+
+    std::string new_indent = indent + "  ";
+    os << "{";
+    if (m_prettyprint)
+    {
+      os << std::endl;
+    }
+    for (std::size_t i = 0; i < object->size(); ++i)
+    {
+      Node member = object->at(i);
+      if (m_prettyprint)
+      {
+        os << new_indent;
+      }
+
+      emit_value(os, new_indent, member->front());
+      os << ":";
+      if (m_prettyprint)
+      {
+        os << " ";
+      }
+      emit_value(os, new_indent, member->back());
+
+      if (i < object->size() - 1)
+      {
+        os << ",";
+      }
+      if (m_prettyprint)
+      {
+        os << std::endl;
+      }
+    }
+    if (m_prettyprint)
+    {
+      os << indent;
+    }
+    os << "}";
+  }
+
+  void JSONEmitter::emit_array(
+    std::ostream& os, const std::string& indent, const Node& array)
+  {
+    if (array->empty())
+    {
+      os << "[]";
+      return;
+    }
+
+    std::string new_indent = indent + "  ";
+    os << "[";
+    if (m_prettyprint)
+    {
+      os << std::endl;
+    }
+    for (std::size_t i = 0; i < array->size(); ++i)
+    {
+      Node element = array->at(i);
+      if (m_prettyprint)
+      {
+        os << new_indent;
+      }
+      emit_value(os, new_indent, element);
+
+      if (i < array->size() - 1)
+      {
+        os << ",";
+      }
+
+      if (m_prettyprint)
+      {
+        os << std::endl;
+      }
+    }
+    if (m_prettyprint)
+    {
+      os << indent;
+    }
+    os << "]";
+  }
+
+  void JSONEmitter::emit_value(
+    std::ostream& os, const std::string& indent, const Node& value)
+  {
+    if (value->in({Number, String, True, False, Null}))
+    {
+      os << value->location().view();
+    }
+    else if (value == Object)
+    {
+      emit_object(os, indent, value);
+    }
+    else if (value == Array)
+    {
+      emit_array(os, indent, value);
+    }
+    else
+    {
+      std::ostringstream message;
+      message << "Unspected node type: " << value->type().str();
+      throw std::runtime_error(message.str());
+    }
+  }
+
+  void JSONEmitter::emit(std::ostream& os, const Node& value)
+  {
+    if (value == Top)
+    {
+      for (auto element : *value)
+      {
+        emit_value(os, "", element);
+      }
+    }
+    else
+    {
+      emit_value(os, "", value);
+    }
+  }
+}

--- a/parsers/json/emitter.cc
+++ b/parsers/json/emitter.cc
@@ -24,6 +24,7 @@ namespace trieste::json
     for (std::size_t i = 0; i < object->size(); ++i)
     {
       Node member = object->at(i);
+      assert(member == Member);
       if (m_prettyprint)
       {
         os << new_indent;
@@ -112,7 +113,7 @@ namespace trieste::json
     else
     {
       std::ostringstream message;
-      message << "Unspected node type: " << value->type().str();
+      message << "Unexpected node type: " << value->type().str();
       throw std::runtime_error(message.str());
     }
   }

--- a/parsers/json/json.cc
+++ b/parsers/json/json.cc
@@ -1,0 +1,108 @@
+#include "json.h"
+
+namespace
+{
+  using namespace trieste;
+  using namespace trieste::json;
+
+  std::size_t invalid_tokens(
+    Node n, std::initializer_list<Token> tokens, const std::string& message)
+  {
+    std::size_t changes = 0;
+    for (auto child : *n)
+    {
+      if (child->in(tokens))
+      {
+        n->replace(child, err(child, message));
+        changes += 1;
+      }
+      else
+      {
+        changes += invalid_tokens(child, tokens, message);
+      }
+    }
+
+    return changes;
+  }
+}
+
+namespace trieste::json
+{
+
+  const auto ValueTokens = T(Object, Array, String, Number, True, False, Null);
+
+  PassDef groups()
+  {
+    PassDef groups = {
+      "groups",
+      wf_groups,
+      dir::bottomup,
+      {
+        In(Array) * T(Group)[Group] >>
+          [](Match& _) { return ArrayGroup << *_[Group]; },
+
+        In(Object) * T(Group)[Group] >>
+          [](Match& _) { return ObjectGroup << *_[Group]; },
+
+        In(Top) *
+            (T(File) << ((T(Group) << (ValueTokens[Value] * End)) * End)) >>
+          [](Match& _) { return _(Value); },
+
+        // errors
+        In(Top) * T(File)[File] >>
+          [](Match& _) { return err(_[File], "Invalid JSON"); },
+
+        In(ArrayGroup) * T(Colon)[Colon] >>
+          [](Match& _) { return err(_[Colon], "Invalid colon in array"); },
+      }};
+
+    return groups;
+  }
+
+  PassDef structure()
+  {
+    PassDef structure = {
+      "structure",
+      wf_structure,
+      dir::bottomup,
+      {
+        In(ArrayGroup) * (Start * ValueTokens[Value]) >>
+          [](Match& _) { return (Value << _(Value)); },
+
+        In(ArrayGroup) * (T(Value)[Lhs] * T(Comma) * ValueTokens[Rhs]) >>
+          [](Match& _) { return Seq << _(Lhs) << (Value << _(Rhs)); },
+
+        In(Array) * (T(ArrayGroup) << (T(Value)++[Array] * End)) >>
+          [](Match& _) { return Seq << _[Array]; },
+
+        In(Array) * T(Value)[Value] >>
+          [](Match& _) { return _(Value)->front(); },
+
+        In(ObjectGroup) *
+            (Start * T(String)[Lhs] * T(Colon) * ValueTokens[Rhs]) >>
+          [](Match& _) { return (Member << _(Lhs) << _(Rhs)); },
+
+        In(ObjectGroup) *
+            (T(Member)[Member] * T(Comma) * T(String)[Lhs] * T(Colon) *
+             ValueTokens[Rhs]) >>
+          [](Match& _) {
+            return Seq << _(Member) << (Member << _(Lhs) << _(Rhs));
+          },
+
+        In(Object) * (T(ObjectGroup) << (T(Member)++[Object] * End)) >>
+          [](Match& _) { return Seq << _[Object]; },
+      }};
+
+    structure.post([&](Node n) {
+      return invalid_tokens(n, {ObjectGroup}, "Invalid object") +
+        invalid_tokens(n, {ArrayGroup}, "Invalid array");
+    });
+
+    return structure;
+  };
+
+  std::vector<Pass> passes()
+  {
+    return {groups(), structure()};
+  }
+}

--- a/parsers/json/json.cc
+++ b/parsers/json/json.cc
@@ -29,7 +29,7 @@ namespace
 namespace trieste::json
 {
 
-  const auto ValueTokens = T(Object, Array, String, Number, True, False, Null);
+  const auto ValueToken = T(Object, Array, String, Number, True, False, Null);
 
   PassDef groups()
   {
@@ -45,7 +45,7 @@ namespace trieste::json
           [](Match& _) { return ObjectGroup << *_[Group]; },
 
         In(Top) *
-            (T(File) << ((T(Group) << (ValueTokens[Value] * End)) * End)) >>
+            (T(File) << ((T(Group) << (ValueToken[Value] * End)) * End)) >>
           [](Match& _) { return _(Value); },
 
         // errors
@@ -66,10 +66,10 @@ namespace trieste::json
       wf_structure,
       dir::bottomup,
       {
-        In(ArrayGroup) * (Start * ValueTokens[Value]) >>
+        In(ArrayGroup) * (Start * ValueToken[Value]) >>
           [](Match& _) { return (Value << _(Value)); },
 
-        In(ArrayGroup) * (T(Value)[Lhs] * T(Comma) * ValueTokens[Rhs]) >>
+        In(ArrayGroup) * (T(Value)[Lhs] * T(Comma) * ValueToken[Rhs]) >>
           [](Match& _) { return Seq << _(Lhs) << (Value << _(Rhs)); },
 
         In(Array) * (T(ArrayGroup) << (T(Value)++[Array] * End)) >>
@@ -79,12 +79,12 @@ namespace trieste::json
           [](Match& _) { return _(Value)->front(); },
 
         In(ObjectGroup) *
-            (Start * T(String)[Lhs] * T(Colon) * ValueTokens[Rhs]) >>
+            (Start * T(String)[Lhs] * T(Colon) * ValueToken[Rhs]) >>
           [](Match& _) { return (Member << _(Lhs) << _(Rhs)); },
 
         In(ObjectGroup) *
             (T(Member)[Member] * T(Comma) * T(String)[Lhs] * T(Colon) *
-             ValueTokens[Rhs]) >>
+             ValueToken[Rhs]) >>
           [](Match& _) {
             return Seq << _(Member) << (Member << _(Lhs) << _(Rhs));
           },

--- a/parsers/json/json.cc
+++ b/parsers/json/json.cc
@@ -5,20 +5,20 @@ namespace
   using namespace trieste;
   using namespace trieste::json;
 
-  std::size_t invalid_tokens(
-    Node n, std::initializer_list<Token> tokens, const std::string& message)
+  std::size_t
+  invalid_tokens(Node n, const std::map<Token, std::string>& token_messages)
   {
     std::size_t changes = 0;
     for (auto child : *n)
     {
-      if (child->in(tokens))
+      if (token_messages.count(child->type()) > 0)
       {
-        n->replace(child, err(child, message));
+        n->replace(child, err(child, token_messages.at(child->type())));
         changes += 1;
       }
       else
       {
-        changes += invalid_tokens(child, tokens, message);
+        changes += invalid_tokens(child, token_messages);
       }
     }
 
@@ -94,8 +94,8 @@ namespace trieste::json
       }};
 
     structure.post([&](Node n) {
-      return invalid_tokens(n, {ObjectGroup}, "Invalid object") +
-        invalid_tokens(n, {ArrayGroup}, "Invalid array");
+      return invalid_tokens(
+        n, {{ObjectGroup, "Invalid object"}, {ArrayGroup, "Invalid array"}});
     });
 
     return structure;

--- a/parsers/json/parse.cc
+++ b/parsers/json/parse.cc
@@ -1,0 +1,91 @@
+#include "json.h"
+
+namespace trieste::json
+{
+  Parse parser()
+  {
+    Parse p(depth::file, wf_parse);
+    std::shared_ptr<std::vector<char>> stack =
+      std::make_shared<std::vector<char>>();
+
+    p("start",
+      {"[ \r\n\t]+" >> [](auto&) { return; },
+
+       ":" >> [](auto& m) { m.add(Colon); },
+
+       "," >> [](auto& m) { m.add(Comma); },
+
+       "{" >>
+         [stack](auto& m) {
+           if (stack->size() > 500)
+           {
+             // TODO: Remove this once Trieste can handle deeper stacks
+             m.error("Too many nested objects");
+             return;
+           }
+           m.push(Object);
+           m.push(Group);
+           stack->push_back('{');
+         },
+
+       "}" >>
+         [stack](auto& m) {
+           if (stack->empty() || stack->back() != '{')
+           {
+             m.error("Mismatched braces");
+             return;
+           }
+           stack->pop_back();
+           m.term();
+           m.pop(Object);
+         },
+
+       R"(\[)" >>
+         [stack](auto& m) {
+           if (stack->size() > 500)
+           {
+             // TODO: Remove this once Trieste can handle deeper stacks
+             m.error("Too many nested objects");
+             return;
+           }
+           m.push(Array);
+           m.push(Group);
+           stack->push_back('[');
+         },
+
+       "]" >>
+         [stack](auto& m) {
+           if (stack->empty() || stack->back() != '[')
+           {
+             m.error("Mismatched brackets");
+             return;
+           }
+           stack->pop_back();
+           m.term();
+           m.pop(Array);
+         },
+
+       "true" >> [](auto& m) { m.add(True); },
+
+       "false" >> [](auto& m) { m.add(False); },
+
+       "null" >> [](auto& m) { m.add(Null); },
+
+       R"(-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][-+]?[0-9]+)?)" >>
+         [](auto& m) { m.add(Number); },
+
+       R"("(?:[^"\\\x00-\x1F]+|\\["\\\/bfnrt]|\\u[[:xdigit:]]{4})*")" >>
+         [](auto& m) { m.add(String); },
+
+       "." >> [](auto& m) { m.error("Invalid character"); }});
+
+    p.done([stack](auto& m) {
+      if (!stack->empty())
+      {
+        m.error("Mismatched braces or brackets");
+      }
+    });
+
+    return p;
+  }
+}

--- a/parsers/json/parse.cc
+++ b/parsers/json/parse.cc
@@ -71,9 +71,23 @@ namespace trieste::json
 
        "null" >> [](auto& m) { m.add(Null); },
 
+       // RE for a JSON number:
+       // -? : optional minus sign
+       // (?:0|[1-9][0-9]*) : either a single 0, or 1-9 followed by any digits
+       // (?:\.[0-9]+)? : optionally, a single period followed by one or more digits (fraction)
+       // (?:[eE][-+]?[0-9]+)? : optionally, an exponent. This can start with e or E,
+       //                        have +/-/nothing, and then 1 or more digits
        R"(-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][-+]?[0-9]+)?)" >>
          [](auto& m) { m.add(Number); },
 
+       // RE for a JSON string:
+       // " : a double quote followed by either:
+       // 1. [^"\\\x00-\x1F]+ : one or more characters that are not a double quote, backslash,
+       //                       or a control character from 00-1f
+       // 2. \\["\\\/bfnrt] : a backslash followed by one of the characters ", \, /, b, f, n, r, or t
+       // 3. \\u[[:xdigit:]]{4} : a backslash followed by u, followed by 4 hex digits
+       // zero or more times and then
+       // " : a double quote
        R"("(?:[^"\\\x00-\x1F]+|\\["\\\/bfnrt]|\\u[[:xdigit:]]{4})*")" >>
          [](auto& m) { m.add(String); },
 

--- a/parsers/json/reader.cc
+++ b/parsers/json/reader.cc
@@ -1,0 +1,149 @@
+#include "json.h"
+#include "trieste/source.h"
+
+namespace trieste::json
+{
+  JSONReader::JSONReader(const std::filesystem::path& path)
+  : JSONReader(SourceDef::load(path))
+  {}
+
+  JSONReader::JSONReader(const std::string& yaml)
+  : JSONReader(SourceDef::synthetic(yaml))
+  {}
+
+  JSONReader::JSONReader(const Source& source)
+  : m_source(source),
+    m_debug_enabled(false),
+    m_debug_path("."),
+    m_well_formed_checks_enabled(false)
+  {}
+
+  JSONReader& JSONReader::debug_enabled(bool value)
+  {
+    m_debug_enabled = value;
+    return *this;
+  }
+
+  bool JSONReader::debug_enabled() const
+  {
+    return m_debug_enabled;
+  }
+
+  JSONReader& JSONReader::well_formed_checks_enabled(bool value)
+  {
+    m_well_formed_checks_enabled = value;
+    return *this;
+  }
+
+  bool JSONReader::well_formed_checks_enabled() const
+  {
+    return m_well_formed_checks_enabled;
+  }
+
+  JSONReader& JSONReader::debug_path(const std::filesystem::path& path)
+  {
+    m_debug_path = path;
+    return *this;
+  }
+
+  const std::filesystem::path& JSONReader::debug_path() const
+  {
+    return m_debug_path;
+  }
+
+  Node has_parse_error(Node n)
+  {
+    std::vector<Node> stack;
+    stack.push_back(n);
+    while (!stack.empty())
+    {
+      auto current = stack.back();
+      stack.pop_back();
+      if (current->in({Error, ErrorSeq}))
+      {
+        return current;
+      }
+      for (auto& child : *current)
+      {
+        stack.push_back(child);
+      }
+    }
+
+    return nullptr;
+  }
+
+  void JSONReader::read()
+  {
+    auto ast = NodeDef::create(Top);
+    Parse parse = json::parser();
+    ast << parse.sub_parse("json", File, m_source);
+    Node maybe_error = has_parse_error(ast);
+    if (has_parse_error(ast))
+    {
+      m_element = ErrorSeq << maybe_error;
+      return;
+    }
+
+    auto passes = json::passes();
+    PassRange pass_range(passes, parse.wf(), "parse");
+    bool ok;
+    Nodes error_nodes;
+    std::string failed_pass;
+    {
+      logging::Info summary;
+      summary << "---------" << std::endl;
+      std::filesystem::path debug_path;
+      if (m_debug_enabled)
+        debug_path = m_debug_path;
+      auto p = default_process(
+        summary, m_well_formed_checks_enabled, "json", debug_path);
+
+      p.set_error_pass(
+        [&error_nodes, &failed_pass](Nodes& errors, std::string pass_name) {
+          error_nodes = errors;
+          failed_pass = pass_name;
+        });
+
+      ok = p.build(ast, pass_range);
+      summary << "---------" << std::endl;
+    }
+
+    if (ok)
+    {
+      m_element = ast;
+      return;
+    }
+
+    logging::Trace() << "Read failed: " << failed_pass;
+    if (error_nodes.empty())
+    {
+      logging::Trace() << "No error nodes so assuming wf error";
+      error_nodes.push_back(err(ast->clone(), "Failed at pass " + failed_pass));
+    }
+
+    Node error_result = NodeDef::create(ErrorSeq);
+    for (auto& error : error_nodes)
+    {
+      error_result->push_back(error);
+    }
+
+    m_element = error_result;
+  }
+
+  bool JSONReader::has_errors() const
+  {
+    return m_element->type() == ErrorSeq;
+  }
+
+  std::string JSONReader::error_message() const
+  {
+    std::ostringstream error;
+    error << m_element;
+    return error.str();
+  }
+
+  const Node& JSONReader::element() const
+  {
+    return m_element;
+  }
+}

--- a/parsers/json/reader.cc
+++ b/parsers/json/reader.cc
@@ -51,38 +51,11 @@ namespace trieste::json
     return m_debug_path;
   }
 
-  Node has_parse_error(Node n)
-  {
-    std::vector<Node> stack;
-    stack.push_back(n);
-    while (!stack.empty())
-    {
-      auto current = stack.back();
-      stack.pop_back();
-      if (current->in({Error, ErrorSeq}))
-      {
-        return current;
-      }
-      for (auto& child : *current)
-      {
-        stack.push_back(child);
-      }
-    }
-
-    return nullptr;
-  }
-
   void JSONReader::read()
   {
     auto ast = NodeDef::create(Top);
     Parse parse = json::parser();
     ast << parse.sub_parse("json", File, m_source);
-    Node maybe_error = has_parse_error(ast);
-    if (has_parse_error(ast))
-    {
-      m_element = ErrorSeq << maybe_error;
-      return;
-    }
 
     auto passes = json::passes();
     PassRange pass_range(passes, parse.wf(), "parse");

--- a/parsers/test/CMakeLists.txt
+++ b/parsers/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(json_trieste json_trieste.cc)
+
+target_link_libraries(json_trieste
+  PRIVATE
+  trieste::json)
+
+add_executable(json_test json_test.cc)
+
+target_link_libraries(json_test
+  PRIVATE
+  trieste::json)
+
+set(JSON_TEST_SUITE_ROOT ${CMAKE_CURRENT_BINARY_DIR}/../JSONTestSuite/test_parsing)
+
+add_test(NAME json_trieste COMMAND json_trieste test -f WORKING_DIRECTORY $<TARGET_FILE_DIR:json_trieste>)
+add_test(NAME json_test COMMAND json_test -wf ${JSON_TEST_SUITE_ROOT} WORKING_DIRECTORY $<TARGET_FILE_DIR:json_test>)
+
+install(TARGETS json_trieste json_test RUNTIME DESTINATION parsers)

--- a/parsers/test/json_test.cc
+++ b/parsers/test/json_test.cc
@@ -1,0 +1,450 @@
+#include "trieste/json.h"
+#include "trieste/logging.h"
+#include "trieste/utf8.h"
+
+#include <CLI/CLI.hpp>
+#include <filesystem>
+#include <fstream>
+#include <type_traits>
+
+const std::string Green = "\x1b[32m";
+const std::string Yellow = "\x1b[33m";
+const std::string Reset = "\x1b[0m";
+const std::string Red = "\x1b[31m";
+// const std::string White = "\x1b[37m";
+
+enum class Outcome
+{
+  Accept,
+  Reject,
+  Maybe
+};
+
+using namespace trieste::utf8;
+using namespace trieste::json;
+
+std::string replace_whitespace(const std::string& str)
+{
+  std::ostringstream os;
+  for (std::size_t i = 0; i < str.size(); ++i)
+  {
+    switch (str[i])
+    {
+      case ' ':
+        os << rune(183);
+        break;
+
+      case '\t':
+        os << rune(2192);
+        break;
+
+      default:
+        os << str[i];
+        break;
+    }
+  }
+
+  return os.str();
+}
+
+void diff_line(
+  const std::string& actual, const std::string& wanted, std::ostream& os)
+{
+  std::set<std::size_t> errors;
+  std::size_t index = 0;
+  std::size_t length = std::min(actual.size(), wanted.size());
+
+  for (; index < length; ++index)
+  {
+    if (actual[index] != wanted[index])
+    {
+      errors.insert(index);
+    }
+  }
+
+  length = std::max(actual.size(), wanted.size());
+  for (; index < length; ++index)
+  {
+    errors.insert(index);
+  }
+
+  os << "wanted: " << replace_whitespace(wanted) << std::endl;
+  os << "actual: " << replace_whitespace(actual) << std::endl;
+  os << "        ";
+  for (std::size_t i = 0; i < length; ++i)
+  {
+    if (errors.find(i) != errors.end())
+    {
+      os << "^";
+    }
+    else
+    {
+      os << " ";
+    }
+  }
+  os << std::endl;
+}
+
+void diff(
+  const std::string& actual,
+  const std::string& wanted,
+  const std::string& label,
+  std::ostream& os)
+{
+  os << "--- " << label << " ---" << std::endl;
+  std::size_t a = 0;
+  std::size_t w = 0;
+  bool error = false;
+  while (a < actual.size() && w < wanted.size())
+  {
+    std::size_t a_end = actual.find("\n", a);
+    std::size_t w_end = wanted.find("\n", w);
+    std::string a_line = actual.substr(a, a_end - a);
+    std::string w_line = wanted.substr(w, w_end - w);
+    if (a_line != w_line)
+    {
+      diff_line(a_line, w_line, os);
+      error = true;
+      break;
+    }
+    else
+    {
+      os << "  " << a_line;
+    }
+    os << std::endl;
+    a = a_end + 1;
+    w = w_end + 1;
+  }
+
+  if (!error)
+  {
+    while (a < actual.size())
+    {
+      std::size_t a_end = actual.find("\n", a);
+      std::string a_line = actual.substr(a, a_end - a);
+      os << "+ " << a_line << std::endl;
+      a = a_end + 1;
+    }
+
+    while (w < wanted.size())
+    {
+      std::size_t w_end = wanted.find("\n", w);
+      std::string w_line = wanted.substr(w, w_end - w);
+      os << "- " << w_line << std::endl;
+      w = w_end + 1;
+    }
+  }
+
+  os << "--- " << label << " ---" << std::endl;
+}
+
+bool is_ws(char c)
+{
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+void skip_whitespace(
+  std::string::const_iterator& it, std::string::const_iterator end)
+{
+  while (it != end)
+  {
+    if(is_ws(*it)){
+      it++;
+    } else {
+      break;
+    }
+  }
+}
+
+bool diff_json(const std::string& actual, const std::string& wanted)
+{
+  auto a = actual.begin();
+  auto w = wanted.begin();
+  while (a != actual.end() && w != wanted.end())
+  {
+    skip_whitespace(a, actual.end());
+    skip_whitespace(w, wanted.end());
+
+    if (*a != *w)
+    {
+      return true;
+    }
+
+    a++;
+    w++;
+
+    skip_whitespace(a, actual.end());
+    skip_whitespace(w, wanted.end());
+  }
+
+  return false;
+}
+
+struct Result
+{
+  bool accepted;
+  std::string error;
+  bool diff;
+};
+
+struct TestCase
+{
+  std::string name;
+  std::string json;
+  std::filesystem::path filename;
+  Outcome outcome;
+
+  Result run(const std::filesystem::path& debug_path, bool wf_checks)
+  {
+    JSONEmitter emitter;
+    JSONReader reader(json);
+    reader.debug_enabled(!debug_path.empty())
+      .debug_path(debug_path)
+      .well_formed_checks_enabled(wf_checks);
+    reader.read();
+    if (reader.has_errors())
+    {
+      return {false, reader.error_message(), false};
+    }
+
+    std::string actual_json;
+    try
+    {
+      std::ostringstream os;
+      emitter.emit(os, reader.element());
+      actual_json = os.str();
+    }
+    catch (const std::exception& ex)
+    {
+      return {false, ex.what(), false};
+    }
+
+    trieste::logging::Debug() << actual_json;
+
+    if (diff_json(actual_json, json))
+    {
+      std::ostringstream os;
+      diff(actual_json, json, "JSON", os);
+      return {true, os.str(), true};
+    }
+
+    return {true, "", false};
+  }
+
+  static void load(
+    std::vector<TestCase>& test_cases, const std::filesystem::path& file_or_dir)
+  {
+    if (std::filesystem::is_directory(file_or_dir))
+    {
+      for (auto& path : std::filesystem::directory_iterator(file_or_dir))
+      {
+        load(test_cases, path);
+      }
+    }
+    else
+    {
+      std::filesystem::path file = file_or_dir;
+      if (file.extension() == ".json")
+      {
+        std::string json = read_to_end(file, true);
+        std::string name = file.stem().string();
+        Outcome outcome;
+        switch (name[0])
+        {
+          case 'y':
+            outcome = Outcome::Accept;
+            break;
+          case 'n':
+            outcome = Outcome::Reject;
+            break;
+          case 'i':
+            outcome = Outcome::Maybe;
+            break;
+          default:
+            throw std::runtime_error("Invalid test case name: " + name);
+        }
+        test_cases.push_back({name, json, file, outcome});
+      }
+    }
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  CLI::App app;
+
+  app.set_help_all_flag("--help-all", "Expand all help");
+
+  std::vector<std::filesystem::path> case_paths;
+  app.add_option("case,-c,--case", case_paths, "Test case JSON directory");
+
+  std::filesystem::path debug_path;
+  app.add_option(
+    "-a,--ast", debug_path, "Output the AST (debugging for test case parser)");
+
+  bool wf_checks{false};
+  app.add_flag("-w,--wf", wf_checks, "Enable well-formedness checks (slow)");
+
+  bool verbose{false};
+  app.add_flag("-v,--verbose", verbose, "Verbose output (for debugging)");
+
+  bool strict{false};
+  app.add_flag("-s,--strict", strict, "Strict mode (must pass all tests)");
+
+  bool fail_first{false};
+  app.add_flag(
+    "-f,--fail-first", fail_first, "Stop after first test case failure");
+
+  std::string name_match;
+  app.add_option(
+    "-n,--name",
+    name_match,
+    "Note (or note substring) of specific test to run");
+
+  try
+  {
+    app.parse(argc, argv);
+  }
+  catch (const CLI::ParseError& e)
+  {
+    return app.exit(e);
+  }
+
+  if (verbose)
+  {
+    trieste::logging::set_level<trieste::logging::Debug>();
+    trieste::logging::Output() << "Verbose output enabled";
+  }
+  else
+  {
+    trieste::logging::set_level<trieste::logging::Output>();
+  }
+
+  trieste::logging::Output() << "Loading test cases:";
+  std::vector<TestCase> test_cases;
+  for (auto path : case_paths)
+  {
+    TestCase::load(test_cases, path);
+  }
+
+  std::sort(
+    test_cases.begin(),
+    test_cases.end(),
+    [](const TestCase& lhs, const TestCase& rhs) {
+      return lhs.name < rhs.name;
+    });
+
+  trieste::logging::Output() << test_cases.size() << " loaded";
+
+  int total = 0;
+  int failures = 0;
+  int warnings = 0;
+  for (auto& testcase : test_cases)
+  {
+    if (
+      !name_match.empty() &&
+      testcase.name.find(name_match) == std::string::npos)
+    {
+      continue;
+    }
+
+    total++;
+    std::string name = testcase.name;
+
+    try
+    {
+      auto start = std::chrono::steady_clock::now();
+      auto result = testcase.run(debug_path, wf_checks);
+      auto end = std::chrono::steady_clock::now();
+      const std::chrono::duration<double> elapsed = end - start;
+
+      if (result.accepted)
+      {
+        if (testcase.outcome == Outcome::Reject || result.diff)
+        {
+          trieste::logging::Error()
+            << Red << "  FAIL: " << Reset << name << std::fixed
+            << std::setw(62 - name.length()) << std::internal
+            << std::setprecision(3) << elapsed.count() << " sec" << std::endl
+            << "  Expected rejection" << std::endl
+            << "(from " << testcase.filename << ")";
+          failures++;
+        }
+        else
+        {
+          trieste::logging::Output()
+            << Green << "  PASS: " << Reset << name << std::fixed
+            << std::setw(62 - name.length()) << std::internal
+            << std::setprecision(3) << elapsed.count() << " sec";
+        }
+      }
+      else
+      {
+        if (
+          testcase.outcome == Outcome::Accept ||
+          (strict && testcase.outcome == Outcome::Maybe))
+        {
+          failures++;
+          trieste::logging::Error()
+            << Red << "  FAIL: " << Reset << name << std::fixed
+            << std::setw(62 - name.length()) << std::internal
+            << std::setprecision(3) << elapsed.count() << " sec" << std::endl
+            << result.error << std::endl
+            << "(from " << testcase.filename << ")";
+        }
+        else
+        {
+          auto color = Green;
+          if (testcase.outcome == Outcome::Maybe)
+          {
+            color = Yellow;
+            if (strict)
+            {
+              failures++;
+            }
+            else
+            {
+              warnings++;
+            }
+          }
+          trieste::logging::Output()
+            << color << "  PASS: " << Reset << name << std::fixed
+            << std::setw(62 - name.length()) << std::internal
+            << std::setprecision(3) << elapsed.count() << " sec";
+        }
+      }
+    }
+    catch (const std::exception& e)
+    {
+      failures++;
+      trieste::logging::Error()
+        << Red << "  EXCEPTION: " << Reset << name << std::endl
+        << "  " << e.what() << std::endl
+        << "(from " << testcase.filename << ")" << std::endl;
+    }
+    if (fail_first && failures > 0)
+    {
+      break;
+    }
+  }
+
+  if (failures != 0)
+  {
+    trieste::logging::Error()
+      << std::endl
+      << (total - failures) << " / " << total << " passed" << std::endl;
+  }
+  else
+  {
+    trieste::logging::Output()
+      << std::endl
+      << total << " / " << total << " passed" << std::endl;
+  }
+
+  if (warnings > 0)
+  {
+    trieste::logging::Output() << warnings << " warnings" << std::endl;
+  }
+
+  return failures;
+}

--- a/parsers/test/json_trieste.cc
+++ b/parsers/test/json_trieste.cc
@@ -1,0 +1,9 @@
+#include <trieste/driver.h>
+#include <trieste/json.h>
+
+int main(int argc, char** argv)
+{
+  trieste::Driver driver(
+    "json", nullptr, trieste::json::parser(), trieste::json::passes());
+  return driver.run(argc, argv);
+}


### PR DESCRIPTION
This code acts as both additional sample code and also as a fully-functional JSON parser and emitter. In addition to the standard Trieste tests it also includes a test driver which runs tests from https://github.com/nst/JSONTestSuite to insure full RFC 8259 compliance.

Further, this PR adds a UTF-8 header to Trieste which provides a range of useful Unicode parsing and conversion functions.