### PR TITLE
Fix recursive stack depth problems.

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -14,6 +14,7 @@ jobs:
         build-type: [ "Release", "Debug" ]
         standard: [ "", "-DTRIESTE_USE_CXX17=ON" ]
         compiler: [ "", "clang" ]
+        variant: [""]
         
         include:
         - platform: "ubuntu-latest"
@@ -23,18 +24,22 @@ jobs:
           dependencies: "sudo apt install ninja-build"
 
         - platform: "windows-latest"
+          variant:  "build-parser-tests"
           build-type: "Release"
           cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
         
         - platform: "macos-latest"
+          variant:  "build-parser-tests"
           build-type: "Release"
           cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
 
         - platform: "ubuntu-latest"
+          variant: "asan"
           build-type: "Release"
           cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANTIZE=address"
 
         - platform: "ubuntu-latest"
+          variant: "ubsan"
           build-type: "Release"
           cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANTIZE=undefined"
 
@@ -50,6 +55,8 @@ jobs:
       fail-fast: false
 
     runs-on: ${{matrix.platform}}
+
+    name: ${{matrix.platform}} ${{matrix.build-type}} ${{matrix.standard}} ${{matrix.compiler}} ${{matrix.variant}}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -36,12 +36,12 @@ jobs:
         - platform: "ubuntu-latest"
           variant: "asan"
           build-type: "Release"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANTIZE=address"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=address"
 
         - platform: "ubuntu-latest"
           variant: "ubsan"
           build-type: "Release"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANTIZE=undefined"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=undefined"
 
         exclude:
         # Mac is already using clang.

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -30,6 +30,14 @@ jobs:
           build-type: "Release"
           cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
 
+        - platform: "ubuntu-latest"
+          build-type: "Release"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANTIZE=address"
+
+        - platform: "ubuntu-latest"
+          build-type: "Release"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANTIZE=undefined"
+
         exclude:
         # Mac is already using clang.
         - platform: "macos-latest"

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -36,12 +36,12 @@ jobs:
         - platform: "ubuntu-latest"
           variant: "asan"
           build-type: "Release"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=address"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=address -DTRIESTE_BUILD_PARSER_TESTS=1"
 
         - platform: "ubuntu-latest"
           variant: "ubsan"
           build-type: "Release"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=undefined"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=undefined -DTRIESTE_BUILD_PARSER_TESTS=1"
 
         exclude:
         # Mac is already using clang.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ set(SNMALLOC_USE_CXX17 ${TRIESTE_USE_CXX17})
 
 set(RE2_BUILD_TESTING OFF CACHE INTERNAL "Turn off RE2 tests")
 
+set(TRIESTE_SANITIZE "" CACHE STRING "Argument to pass to sanitize (disabled by default)")
+
+
 FetchContent_Declare(
   snmalloc
   GIT_REPOSITORY https://github.com/microsoft/snmalloc
@@ -84,6 +87,11 @@ if(TRIESTE_USE_CXX17)
   target_compile_definitions(trieste INTERFACE cxx_std_17)
 else()
   target_compile_definitions(trieste INTERFACE cxx_std_20)
+endif()
+
+if (TRIESTE_SANITIZE)
+  target_compile_options(trieste INTERFACE -g -fsanitize=${TRIESTE_SANITIZE} -fno-omit-frame-pointer)
+  target_link_libraries(trieste INTERFACE -fsanitize=${TRIESTE_SANITIZE})
 endif()
 
 if(MSVC)

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -680,6 +680,36 @@ namespace trieste
       out << ")";
     }
 
+    template<typename Pre, typename Post>
+    SNMALLOC_FAST_PATH void traverse(Pre pre, Post post)
+    {
+      Node root = shared_from_this();
+      if (!pre(root))
+        return;
+
+      std::vector<std::pair<Node&, NodeIt>> path;
+      path.push_back({root, root->begin()});
+      while (!path.empty())
+      {
+        auto& [node, it] = path.back();
+        if (it != node->end())
+        {
+          Node& curr = *it;
+          it++;
+          if (pre(curr))
+          {
+            path.push_back({curr, curr->begin()});
+          }
+        }
+        else
+        {
+          post(node);
+          path.pop_back();
+        }
+      }
+      post(root);
+    }
+
     /**
      * Pass a Nodes that is filled in with the found errors.
      */

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -169,7 +169,7 @@ namespace trieste
 
       recursive = true;
 
-DF      while (!work_list.empty())
+      while (!work_list.empty())
       {
         // clear will potentially call destructor recursively, so we need to
         // have finished modifying the work_list before calling it, hence moving

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -155,30 +155,62 @@ namespace trieste
     }
 
   public:
+    /**
+     * @brief Destroy the Node Def object
+     *
+     * This destructor will transitively destroy the children of the node.
+     *
+     * For deep graphs this can be a problem leading to stack overflow if we
+     * just allow arbitrary reentrancy through ~NodeDef. This design ensures
+     * there at most two calls to the destructor on the stack.
+     *
+     * There are two cases where this destructor is called:
+     *   - Outer case: there are no other calls to the destructor on the stack
+     *   - Re-entrant case: there is one more call to the destructor on the
+     * stack
+     *
+     * This destructor uses thread local state to detect which case it is in
+     * using
+     *
+     *   thread_local std::vector<Nodes>* work_list{nullptr};
+     *
+     * On entry to the destructor if the work_list is nullptr, then we are in
+     * the Outer case. The Outer case sets up a work_list, stores a pointer to
+     * it in the thread_local and processes the work_list, which includes this
+     * nodes children.  Processing the worklist can result in calls to ~NodeDef.
+     * When the work_list is empty, the thread_local is nullified. Thus the next
+     * call to NodeDef will be considered an Outer case.
+     *
+     * The Re-entrant case is detected by the work_list being non-null.
+     * In this case, the children are moved into the work_list and the
+     * destructor returns. The children will be processed by the Outer case.
+     */
     ~NodeDef()
     {
       // Contains a pointer to a vector on the stack for handling the
       // recursive destruction of the AST.
       // We don't use an actual vector in the TLS as the destruction
       // of the TLS can cause problems on some platforms.
-      thread_local std::vector<Nodes>* work_list;
+      thread_local std::vector<Nodes>* work_list{nullptr};
 
       if (work_list)
       {
+        // Re-entrant case, move the children into the work_list and return.
         work_list->push_back(std::move(children));
         return;
       }
 
+      // Outer case, set up the work_list, and process it.
       std::vector<Nodes> work_list_local;
       work_list = &work_list_local;
 
       work_list_local.push_back(std::move(children));
-      
+
       while (!work_list_local.empty())
       {
-        // clear will potentially call destructor recursively, so we need to
-        // have finished modifying the work_list before calling it, hence moving
-        // the nodes out of the work_list into a local variable.
+        // clear will potentially call this destructor recursively, so we need
+        // to have finished modifying the work_list before calling it, hence
+        // moving the nodes out of the work_list into a local variable.
         auto nodes = std::move(work_list_local.back());
         work_list_local.pop_back();
         nodes.clear();

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -484,51 +484,60 @@ namespace trieste
         if (shapes.empty())
           return true;
 
-        if (!node)
-          return false;
+        bool ok = true;
 
-        if (node == Error)
-          return true;
+        auto pre = [&](auto& current) {
+          if (current == Error)
+            return false;
 
-        auto find = shapes.find(node->type());
-
-        if (find == shapes.end())
-        {
-          // If the shape isn't present, assume it should be empty.
-          if (node->empty())
-            return true;
-
-          logging::Error() << node->location().origin_linecol()
-                           << ": expected 0 children, found " << node->size()
-                           << std::endl
-                           << node->location().str() << node << std::endl;
-          return false;
-        }
-
-        bool ok = std::visit(
-          [&](auto& shape) { return shape.check(node); }, find->second);
-
-        for (auto& child : *node)
-        {
-          if (child->parent() != node.get())
+          if (!current)
           {
-            logging::Error()
-              << child->location().origin_linecol()
-              << ": this node appears in the AST multiple times:" << std::endl
-              << child->location().str() << child << std::endl
-              << node->location().origin_linecol() << ": here:" << std::endl
-              << node << std::endl
-              << child->parent()->location().origin_linecol()
-              << ": and here:" << std::endl
-              << child->parent() << std::endl
-              << "Your language implementation needs to explicitly clone "
-                 "nodes if they're duplicated."
-              << std::endl;
             ok = false;
+            return false;
           }
 
-          ok = check(child) && ok;
-        }
+          auto find = shapes.find(current->type());
+
+          if (find == shapes.end())
+          {
+            // If the shape isn't present, assume it should be empty.
+            if (current->empty())
+              return false;
+
+            logging::Error() << current->location().origin_linecol()
+                            << ": expected 0 children, found " << current->size()
+                            << std::endl
+                            << current->location().str() << current << std::endl;
+            ok = false;
+            return false;
+          }
+
+          ok = std::visit(
+            [&](auto& shape) { return shape.check(current); }, find->second) && ok;
+
+          for (auto& child : *current)
+          {
+            if (child->parent() != current.get())
+            {
+              logging::Error()
+                << child->location().origin_linecol()
+                << ": this node appears in the AST multiple times:" << std::endl
+                << child->location().str() << child << std::endl
+                << current->location().origin_linecol() << ": here:" << std::endl
+                << current << std::endl
+                << child->parent()->location().origin_linecol()
+                << ": and here:" << std::endl
+                << child->parent() << std::endl
+                << "Your language implementation needs to explicitly clone "
+                  "nodes if they're duplicated."
+                << std::endl;
+              ok = false;
+            }
+          }
+          return true;
+        };
+
+        node->traverse(pre, [](Node&){});
 
         return ok;
       }

--- a/parsers/json/json.cc
+++ b/parsers/json/json.cc
@@ -6,21 +6,24 @@ namespace
   using namespace trieste::json;
 
   std::size_t
-  invalid_tokens(Node n, const std::map<Token, std::string>& token_messages)
+  invalid_tokens(Node node, const std::map<Token, std::string>& token_messages)
   {
     std::size_t changes = 0;
-    for (auto child : *n)
-    {
-      if (token_messages.count(child->type()) > 0)
+
+    node->traverse([&](Node& n){
+      if (n->type() == Error)
+        return false;
+
+      for (auto child : *n)
       {
-        n->replace(child, err(child, token_messages.at(child->type())));
-        changes += 1;
+        if (token_messages.count(child->type()) > 0)
+        {
+          n->replace(child, err(child, token_messages.at(child->type())));
+          changes += 1;
+        }
       }
-      else
-      {
-        changes += invalid_tokens(child, token_messages);
-      }
-    }
+      return true;
+    });
 
     return changes;
   }

--- a/parsers/json/parse.cc
+++ b/parsers/json/parse.cc
@@ -17,12 +17,6 @@ namespace trieste::json
 
        "{" >>
          [stack](auto& m) {
-           if (stack->size() > 500)
-           {
-             // TODO: Remove this once Trieste can handle deeper stacks
-             m.error("Too many nested objects");
-             return;
-           }
            m.push(Object);
            m.push(Group);
            stack->push_back('{');
@@ -42,12 +36,6 @@ namespace trieste::json
 
        R"(\[)" >>
          [stack](auto& m) {
-           if (stack->size() > 500)
-           {
-             // TODO: Remove this once Trieste can handle deeper stacks
-             m.error("Too many nested objects");
-             return;
-           }
            m.push(Array);
            m.push(Group);
            stack->push_back('[');


### PR DESCRIPTION
The rewrite engine used an efficient path based traversal that was iterative with effectively pre and post-order actions.  This PR factors that into ast.h, and then uses it for various operations to prevent stack overflow on deep asts.

It also fixes the recursive delete problem that you get from shared_ptr, by building a work list of nodes that need to be destructed.
