### PR TITLE
Fix to #309

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -778,7 +778,6 @@ namespace trieste
           path.pop_back();
         }
       }
-      post(root);
     }
 
     /**


### PR DESCRIPTION
The traverse function was calling post(root) twice:
  once just before exiting the loop, and
  once just after the loop.

This removes the unneccessary additional call.