### PR TITLE
Add source_location to help with debugging.

### DIFF
--- a/include/trieste/debug.h
+++ b/include/trieste/debug.h
@@ -25,6 +25,9 @@ namespace trieste
 #else
     struct DebugLocation
     {
+      // Dummy value as we got a UBSan Misaligned Use without this.
+      // I am assuming that the empty struct was trigger some kind of compiler bug. (MJP)
+      size_t dummy{0};
       DebugLocation() {}
     };
 #endif

--- a/include/trieste/debug.h
+++ b/include/trieste/debug.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <version>
+#ifdef __cpp_lib_source_location
+#  include <source_location>
+#endif
+
+namespace trieste
+{
+  namespace detail
+  {
+    /*
+     * Type used to track where a particular value was constructed in the
+     * source. This aids in debugging and error reporting.
+     */
+#ifdef __cpp_lib_source_location
+    struct DebugLocation
+    {
+      std::source_location location;
+
+      DebugLocation(std::source_location l = std::source_location::current())
+      : location(l)
+      {}
+    };
+#else
+    struct DebugLocation
+    {
+      DebugLocation() {}
+    };
+#endif
+
+    template<typename T>
+    struct Located
+    {
+      T value;
+      DebugLocation location;
+
+      Located(T t, DebugLocation l = {})
+      : value(t), location(l)
+      {}
+    };
+  }
+}

--- a/include/trieste/parse.h
+++ b/include/trieste/parse.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ast.h"
+#include "debug.h"
 #include "gen.h"
 #include "logging.h"
 #include "regex.h"
@@ -28,10 +29,15 @@ namespace trieste
     private:
       RE2 regex;
       ParseEffect effect;
+      DebugLocation dl;
 
     public:
-      RuleDef(const std::string& s, ParseEffect effect_)
-      : regex(s), effect(effect_)
+      RuleDef(Located<const std::string&> s, ParseEffect effect_)
+      : regex(s.value), effect(effect_), dl(s.location)
+      {}
+
+      RuleDef(Located<const char*> s, ParseEffect effect_)
+      : regex(s.value), effect(effect_), dl(s.location)
       {}
     };
 
@@ -473,10 +479,17 @@ namespace trieste
   };
 
   inline detail::Rule
-  operator>>(const std::string& s, detail::ParseEffect effect)
+  operator>>(detail::Located<const std::string&> s, detail::ParseEffect effect)
   {
     return std::make_shared<detail::RuleDef>(s, effect);
   }
+
+  inline detail::Rule
+  operator>>(detail::Located<const char*> s, detail::ParseEffect effect)
+  {
+    return std::make_shared<detail::RuleDef>(s, effect);
+  }
+
 
   inline std::pair<Token, GenLocationF>
   operator>>(const Token& t, GenLocationF f)

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -184,8 +184,8 @@ namespace trieste
 
       for (auto& rule : rules_)
       {
-        const auto& starts = rule.first.get_starts();
-        const auto& parents = rule.first.get_parents();
+        const auto& starts = rule.first.value.get_starts();
+        const auto& parents = rule.first.value.get_parents();
 
         //  This is used to add a rule under a specific parent, or to the
         //  default.
@@ -296,7 +296,7 @@ namespace trieste
         for (auto& rule : specific_rules)
         {
           match.reset();
-          if (SNMALLOC_UNLIKELY(rule.first.match(it, node, match)))
+          if (SNMALLOC_UNLIKELY(rule.first.value.match(it, node, match)))
           {
             replaced = replace(match, rule.second, start, it, node);
             if (replaced != -1)

--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ast.h"
+#include "debug.h"
 #include "token.h"
 #include "regex.h"
 
@@ -881,13 +882,8 @@ namespace trieste
       }
     };
 
-    class Pattern;
-
     template<typename T>
     using Effect = std::function<T(Match&)>;
-
-    template<typename T>
-    using PatternEffect = std::pair<Pattern, Effect<T>>;
 
     class Pattern
     {
@@ -999,6 +995,9 @@ namespace trieste
       }
     };
 
+    template<typename T>
+    using PatternEffect = std::pair<Located<Pattern>, Effect<T>>;
+
     struct RangeContents
     {
       NodeRange range;
@@ -1022,7 +1021,7 @@ namespace trieste
   }
 
   template<typename F>
-  inline auto operator>>(detail::Pattern pattern, F effect)
+  inline auto operator>>(detail::Located<detail::Pattern> pattern, F effect)
     -> detail::PatternEffect<decltype(effect(std::declval<Match&>()))>
   {
     return {pattern, effect};


### PR DESCRIPTION
As several parts of Trieste are dynamic the debugging experience can be a challenge. This uses source_location to provide more information about where a particular rule is defined in the source.