### PR TITLE
Two small changes to the ast

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -727,6 +727,16 @@ namespace trieste
       const_cast<NodeDef*>(this)->traverse(pre, post);
     }
 
+    /*
+     * Useful for calling from inside a debugger.
+     */
+    std::string SNMALLOC_USED_FUNCTION str()
+    {
+      std::ostringstream out;
+      str(out);
+      return out.str();
+    }
+
     class NopPost
     {
     public:

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -282,8 +282,9 @@ namespace trieste
     {
       traverse([&](Node& current) {
         auto& current_loc = current->location_;
-        if (!current_loc.source)
-          current_loc = loc;
+        if (current_loc.source)
+          return false;
+        current_loc = loc;
         return true;
       });
     }

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -280,11 +280,12 @@ namespace trieste
 
     void set_location(const Location& loc)
     {
-      if (!location_.source)
-        location_ = loc;
-
-      for (auto& c : children)
-        c->set_location(loc);
+      traverse([&](Node& current) {
+        auto& current_loc = current->location_;
+        if (!current_loc.source)
+          current_loc = loc;
+        return true;
+      });
     }
 
     void extend(const Location& loc)


### PR DESCRIPTION
* Add a `str` that returns a string.
* Make `set_location` use `traverse`.  Any tree traversal should use `traverse` to handle very large graphs.
