### PR TITLE
Systematic testing should not check wf when errors produced

### DIFF
--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -220,6 +220,14 @@ namespace trieste
                              << std::endl;
 
             auto ok = wf.build_st(new_ast);
+            if (ok)
+            {
+              Nodes errors;
+              new_ast->get_errors(errors);
+              if (!errors.empty())
+                // Pass added error nodes, so doesn't need to satisfy wf.
+                continue;
+            }
             ok = wf.check(new_ast) && ok;
 
             if (!ok)


### PR DESCRIPTION
If the pass has added errors to the AST, then it should be allowed to finish at that point, and hence will not have established the wf condition for the pass.

This considers adding an error node as success for a pass in systematic testing.