### PR TITLE
Adding a flag to enable cleaning the install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(TRIESTE_BUILD_SAMPLES "Specifies whether to build the samples" ON)
 option(TRIESTE_BUILD_PARSERS "Specifies whether to build the parsers" ON)
 option(TRIESTE_BUILD_PARSER_TESTS "Specifies whether to build the parser tests" OFF)
 option(TRIESTE_USE_CXX17 "Specifies whether to target the C++17 standard" OFF)
+option(TRIESTE_CLEAN_INSTALL "Specifies whether to delete all files (recursively) from the install prefix before install" OFF)
 
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 
@@ -103,6 +104,14 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(trieste INTERFACE -Wmismatched-tags -fstandalone-debug)
+endif()
+
+if(TRIESTE_CLEAN_INSTALL)
+  message("${CMAKE_INSTALL_PREFIX} will be recursively cleaned before install")
+  # Clear all existing files and folders from the install directory
+  install(CODE [[
+    file(REMOVE_RECURSE ${CMAKE_INSTALL_PREFIX}/.)
+    ]])
 endif()
 
 # #############################################

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,8 @@
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/dist",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "TRIESTE_BUILD_SAMPLES": "ON"
+                "TRIESTE_BUILD_SAMPLES": "ON",
+                "TRIESTE_CLEAN_INSTALL": "ON"
             }
         },
         {
@@ -20,7 +21,8 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/dist",
-                "TRIESTE_BUILD_SAMPLES": "ON"
+                "TRIESTE_BUILD_SAMPLES": "ON",
+                "TRIESTE_CLEAN_INSTALL": "ON"
             }
         },
         {
@@ -32,7 +34,8 @@
                 "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/dist",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "TRIESTE_BUILD_SAMPLES": "ON"
+                "TRIESTE_BUILD_SAMPLES": "ON",
+                "TRIESTE_CLEAN_INSTALL": "ON"
             }
         },
         {
@@ -42,7 +45,8 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/dist",
-                "TRIESTE_BUILD_SAMPLES": "ON"
+                "TRIESTE_BUILD_SAMPLES": "ON",
+                "TRIESTE_CLEAN_INSTALL": "ON"
             }
         }
     ]


### PR DESCRIPTION
The previous PR #111  removed the install directory cleaning functionality that is expected by various downstream repositories. This PR adds it back in with a flag, to address the concerns raised in #96. Downstream users will need to set `TRIESTE_CLEAN_INSTALL` to `On` to get the old behaviour.