### PR TITLE
Adding the `Fuzzer`class, `NodeRange` -> `span`, and WF contexts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(trieste
 )
 
 if(TRIESTE_USE_CXX17)
-  target_compile_definitions(trieste INTERFACE cxx_std_17)
+  target_compile_definitions(trieste INTERFACE cxx_std_17 TRIESTE_USE_CXX17)
 else()
   target_compile_definitions(trieste INTERFACE cxx_std_20)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(trieste VERSION 1.0.0 LANGUAGES CXX)
 option(TRIESTE_BUILD_SAMPLES "Specifies whether to build the samples" ON)
 option(TRIESTE_BUILD_PARSERS "Specifies whether to build the parsers" ON)
 option(TRIESTE_BUILD_PARSER_TESTS "Specifies whether to build the parser tests" OFF)
+option(TRIESTE_BUILD_PARSER_TOOLS "Specifies whether to build parser tools" OFF)
 option(TRIESTE_USE_CXX17 "Specifies whether to target the C++17 standard" OFF)
 option(TRIESTE_CLEAN_INSTALL "Specifies whether to delete all files (recursively) from the install prefix before install" OFF)
 

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -473,7 +473,7 @@ namespace trieste
 
     void push_back(NodeRange range)
     {
-      for (Node n : range)
+      for (Node& n : range)
         push_back(n);
     }
 
@@ -488,7 +488,7 @@ namespace trieste
 
     void push_back_ephemeral(NodeRange range)
     {
-      for (Node n : range)
+      for (Node& n : range)
         push_back_ephemeral(n);
     }
 
@@ -683,7 +683,7 @@ namespace trieste
       return parent(Top)->fresh(prefix);
     }
 
-    Node clone()
+    Node clone() const
     {
       // This doesn't preserve the symbol table.
       auto node = create(type_, location_);
@@ -1012,7 +1012,7 @@ namespace trieste
 
   inline std::ostream& operator<<(std::ostream& os, const NodeRange& range)
   {
-    for (Node n : range)
+    for (const Node& n : range)
       n->str(os);
 
     return os;

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -10,6 +10,10 @@
 #include <sstream>
 #include <vector>
 
+#ifndef TRIESTE_USE_CXX17
+#  include <span>
+#endif
+
 namespace trieste
 {
   struct indent
@@ -29,11 +33,77 @@ namespace trieste
 
   using Nodes = std::vector<Node>;
   using NodeIt = Nodes::iterator;
-  using NodeRange = std::pair<NodeIt, NodeIt>;
   using NodeSet = std::set<Node, std::owner_less<>>;
 
   template<typename T>
   using NodeMap = std::map<Node, T, std::owner_less<>>;
+
+#ifdef TRIESTE_USE_CXX17
+  class NodeRange
+  {
+  public:
+    NodeRange() {}
+    NodeRange(NodeIt first_, NodeIt second_) : first(first_), second(second_) {}
+    NodeRange(NodeRange&& other) : first(other.first), second(other.second) {}
+    NodeRange(const NodeRange& other) : first(other.first), second(other.second)
+    {}
+
+    NodeRange& operator=(NodeRange&& other)
+    {
+      first = other.first;
+      second = other.second;
+      return *this;
+    }
+
+    NodeRange& operator=(const NodeRange& other)
+    {
+      first = other.first;
+      second = other.second;
+      return *this;
+    }
+
+    bool empty() const
+    {
+      return first == second;
+    }
+
+    std::size_t size() const
+    {
+      return std::distance(first, second);
+    }
+
+    NodeIt begin() const
+    {
+      return first;
+    }
+
+    NodeIt end() const
+    {
+      return second;
+    }
+
+    Node front() const
+    {
+      return *first;
+    }
+
+    Node back() const
+    {
+      return *(second - 1);
+    }
+
+    Node operator[](std::size_t index) const
+    {
+      return *(first + index);
+    }
+
+  private:
+    NodeIt first;
+    NodeIt second;
+  };
+#else
+  using NodeRange = std::span<Node>;
+#endif
 
   class SymtabDef
   {
@@ -231,11 +301,11 @@ namespace trieste
 
     static Node create(const Token& type, NodeRange range)
     {
-      if (range.first == range.second)
+      if (range.empty())
         return create(type);
 
-      return std::shared_ptr<NodeDef>(new NodeDef(
-        type, (*range.first)->location_ * (*(range.second - 1))->location_));
+      return std::shared_ptr<NodeDef>(
+        new NodeDef(type, range.front()->location_ * range.back()->location_));
     }
 
     const Token& type() const
@@ -334,6 +404,17 @@ namespace trieste
       return children.crend();
     }
 
+    auto find_first(Token token, NodeIt begin)
+    {
+      return std::find_if(
+        begin, children.end(), [token](auto& n) { return n->type() == token; });
+    }
+
+    auto contains(Token token)
+    {
+      return find_first(token, children.begin()) != children.end();
+    }
+
     auto find(Node node)
     {
       return std::find(children.begin(), children.end(), node);
@@ -391,8 +472,8 @@ namespace trieste
 
     void push_back(NodeRange range)
     {
-      for (auto it = range.first; it != range.second; ++it)
-        push_back(*it);
+      for (Node n : range)
+        push_back(n);
     }
 
     void push_back_ephemeral(Node node)
@@ -406,8 +487,8 @@ namespace trieste
 
     void push_back_ephemeral(NodeRange range)
     {
-      for (auto it = range.first; it != range.second; ++it)
-        push_back_ephemeral(*it);
+      for (Node n : range)
+        push_back_ephemeral(n);
     }
 
     Node pop_back()
@@ -930,8 +1011,8 @@ namespace trieste
 
   inline std::ostream& operator<<(std::ostream& os, const NodeRange& range)
   {
-    for (auto it = range.first; it != range.second; ++it)
-      (*it)->str(os);
+    for (Node n : range)
+      n->str(os);
 
     return os;
   }

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -406,6 +406,7 @@ namespace trieste
 
     auto find_first(Token token, NodeIt begin)
     {
+      assert((*begin)->parent() == this);   
       return std::find_if(
         begin, children.end(), [token](auto& n) { return n->type() == token; });
     }

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -126,7 +126,7 @@ namespace trieste
 
     int test()
     {
-      wf::new_context();
+      WFContext context;
       int ret = 0;
       for (size_t i = start_index_; i <= end_index_; i++)
       {
@@ -197,8 +197,6 @@ namespace trieste
         wf::pop_front();
         wf::pop_front();
       }
-
-      wf::end_context();
 
       return ret;
     }

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -141,8 +141,8 @@ namespace trieste
         }
 
         logging::Info() << "Testing pass: " << pass->name() << std::endl;
-        wf::push_back(prev);
-        wf::push_back(wf);
+        context.push_back(prev);
+        context.push_back(wf);
 
         for (size_t seed = start_seed_; seed < start_seed_ + seed_count_;
              seed++)
@@ -194,8 +194,8 @@ namespace trieste
           }
         }
 
-        wf::pop_front();
-        wf::pop_front();
+        context.pop_front();
+        context.pop_front();
       }
 
       return ret;

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -1,0 +1,206 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "trieste.h"
+
+#include <random>
+#include <stdexcept>
+
+namespace trieste
+{
+  class Fuzzer
+  {
+  private:
+    std::vector<Pass> passes_;
+    const wf::Wellformed* input_wf_;
+    GenNodeLocationF generators_;
+    size_t max_depth_;
+    uint32_t start_seed_;
+    uint32_t seed_count_;
+    bool failfast_;
+    size_t start_index_;
+    size_t end_index_;
+
+  public:
+    Fuzzer() {}
+
+    Fuzzer(
+      const std::vector<Pass>& passes,
+      const wf::Wellformed& input_wf,
+      GenNodeLocationF generators)
+    : passes_(passes),
+      input_wf_(&input_wf),
+      generators_(generators),
+      max_depth_(10),
+      start_seed_(std::random_device()()),
+      seed_count_(100),
+      failfast_(false),
+      start_index_(1),
+      end_index_(passes.size() - 1)
+    {}
+
+    Fuzzer(const Reader& reader)
+    : Fuzzer(
+        reader.passes(), reader.parser().wf(), reader.parser().generators())
+    {}
+
+    Fuzzer(const Writer& writer, GenNodeLocationF generators)
+    : Fuzzer(writer.passes(), writer.input_wf(), generators)
+    {}
+
+    Fuzzer(const Rewriter& rewriter, GenNodeLocationF generators)
+    : Fuzzer(rewriter.passes(), rewriter.input_wf(), generators)
+    {}
+
+    size_t max_depth() const
+    {
+      return max_depth_;
+    }
+
+    Fuzzer& max_depth(size_t max_depth)
+    {
+      max_depth_ = max_depth;
+      return *this;
+    }
+
+    uint32_t start_seed() const
+    {
+      return start_seed_;
+    }
+
+    Fuzzer& start_seed(uint32_t seed)
+    {
+      start_seed_ = seed;
+      return *this;
+    }
+
+    size_t seed_count() const
+    {
+      return seed_count_;
+    }
+
+    Fuzzer& seed_count(size_t seed_count)
+    {
+      seed_count_ = seed_count;
+      return *this;
+    }
+
+    bool failfast() const
+    {
+      return failfast_;
+    }
+
+    Fuzzer& failfast(bool failfast)
+    {
+      failfast_ = failfast;
+      return *this;
+    }
+
+    size_t start_index() const
+    {
+      return start_index_;
+    }
+
+    Fuzzer& start_index(size_t start_index)
+    {
+      if (start_index == 0)
+      {
+        throw std::invalid_argument("start_index must be greater than 0");
+      }
+
+      start_index_ = start_index;
+      return *this;
+    }
+
+    size_t end_index() const
+    {
+      return end_index_;
+    }
+
+    Fuzzer& end_index(size_t end_index)
+    {
+      end_index_ = end_index;
+      return *this;
+    }
+
+    int test()
+    {
+      wf::new_context();
+      int ret = 0;
+      for (size_t i = start_index_; i <= end_index_; i++)
+      {
+        auto& pass = passes_.at(i - 1);
+        auto& wf = pass->wf();
+        auto& prev = i > 1 ? passes_.at(i - 2)->wf() : *input_wf_;
+
+        if (!prev || !wf)
+        {
+          logging::Info() << "Skipping pass: " << pass->name() << std::endl;
+          continue;
+        }
+
+        logging::Info() << "Testing pass: " << pass->name() << std::endl;
+        wf::push_back(prev);
+        wf::push_back(wf);
+
+        for (size_t seed = start_seed_; seed < start_seed_ + seed_count_;
+             seed++)
+        {
+          auto ast = prev.gen(generators_, seed, max_depth_);
+          logging::Trace() << "============" << std::endl
+                           << "Pass: " << pass->name() << ", seed: " << seed
+                           << std::endl
+                           << "------------" << std::endl
+                           << ast << "------------" << std::endl;
+
+          auto [new_ast, count, changes] = pass->run(ast);
+          logging::Trace() << new_ast << "------------" << std::endl
+                           << std::endl;
+
+          auto ok = wf.build_st(new_ast);
+          if (ok)
+          {
+            Nodes errors;
+            new_ast->get_errors(errors);
+            if (!errors.empty())
+              // Pass added error nodes, so doesn't need to satisfy wf.
+              continue;
+          }
+          ok = wf.check(new_ast) && ok;
+
+          if (!ok)
+          {
+            logging::Error err;
+            if (!logging::Trace::active())
+            {
+              // We haven't printed what failed with Trace earlier, so do it
+              // now. Regenerate the start Ast for the error message.
+              err << "============" << std::endl
+                  << "Pass: " << pass->name() << ", seed: " << seed << std::endl
+                  << "------------" << std::endl
+                  << prev.gen(generators_, seed, max_depth_) << "------------"
+                  << std::endl
+                  << new_ast;
+            }
+
+            err << "============" << std::endl
+                << "Failed pass: " << pass->name() << ", seed: " << seed
+                << std::endl;
+            ret = 1;
+
+            if (failfast_)
+              return ret;
+          }
+        }
+
+        wf::pop_front();
+        wf::pop_front();
+      }
+
+      wf::end_context();
+
+      return ret;
+    }
+  };
+}

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -75,12 +75,12 @@ namespace trieste
       return *this;
     }
 
-    size_t seed_count() const
+    uint32_t seed_count() const
     {
       return seed_count_;
     }
 
-    Fuzzer& seed_count(size_t seed_count)
+    Fuzzer& seed_count(uint32_t seed_count)
     {
       seed_count_ = seed_count;
       return *this;

--- a/include/trieste/passes.h
+++ b/include/trieste/passes.h
@@ -276,8 +276,7 @@ namespace trieste
     {
       size_t index = 1;
 
-      WFContext context;
-      wf::push_back(pass_range.input_wf());
+      WFContext context(pass_range.input_wf());
 
       Nodes errors;
 
@@ -294,11 +293,11 @@ namespace trieste
 
         auto now = std::chrono::high_resolution_clock::now();
         auto& pass = pass_range();
-        wf::push_back(pass->wf());
+        context.push_back(pass->wf());
 
         auto [new_ast, count, changes] = pass->run(ast);
         ast = new_ast;
-        wf::pop_front();
+        context.pop_front();
 
         ++pass_range;
 
@@ -314,8 +313,6 @@ namespace trieste
 
         last_pass = pass->name();
       }
-
-      wf::pop_front();
 
       return {ok, last_pass, ast, errors};
     }

--- a/include/trieste/passes.h
+++ b/include/trieste/passes.h
@@ -276,7 +276,7 @@ namespace trieste
     {
       size_t index = 1;
 
-      wf::new_context();
+      WFContext context;
       wf::push_back(pass_range.input_wf());
 
       Nodes errors;
@@ -316,7 +316,6 @@ namespace trieste
       }
 
       wf::pop_front();
-      wf::end_context();
 
       return {ok, last_pass, ast, errors};
     }

--- a/include/trieste/passes.h
+++ b/include/trieste/passes.h
@@ -257,11 +257,11 @@ namespace trieste
       auto ok = bool(ast);
 
       ok = ok && wf.build_st(ast);
-      
+
       if (ast)
         ast->get_errors(errors);
       ok = ok && errors.empty();
-      
+
       ok = ok && (!check_well_formed || wf.check(ast));
 
       return ok;
@@ -276,6 +276,7 @@ namespace trieste
     {
       size_t index = 1;
 
+      wf::new_context();
       wf::push_back(pass_range.input_wf());
 
       Nodes errors;
@@ -315,6 +316,7 @@ namespace trieste
       }
 
       wf::pop_front();
+      wf::end_context();
 
       return {ok, last_pass, ast, errors};
     }

--- a/include/trieste/reader.h
+++ b/include/trieste/reader.h
@@ -258,5 +258,16 @@ namespace trieste
       input_ = SourceDef::synthetic(contents);
       return *this;
     }
+
+    Reader& postparse(Parse::PostF func)
+    {
+      parser_.postparse(func);
+      return *this;
+    }
+
+    const wf::Wellformed& output_wf() const
+    {
+      return passes_.back()->wf();
+    }
   };
 }

--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -4,8 +4,8 @@
 
 #include "ast.h"
 #include "debug.h"
-#include "token.h"
 #include "regex.h"
+#include "token.h"
 
 #include <array>
 #include <cassert>
@@ -74,9 +74,9 @@ namespace trieste
         if (valid)
         {
           auto it = map.find(token);
-          if ((it != map.end()) && *it->second.first)
+          if ((it != map.end()) && it->second.front())
           {
-            return *it->second.first;
+            return it->second.front();
           }
         }
         if (i == 0)
@@ -1119,11 +1119,9 @@ namespace trieste
 
   inline Node operator<<(Node node, detail::RangeContents range_contents)
   {
-    for (auto it = range_contents.range.first;
-         it != range_contents.range.second;
-         ++it)
+    for (Node n : range_contents.range)
     {
-      node->push_back({(*it)->begin(), (*it)->end()});
+      node->push_back({n->begin(), n->end()});
     }
 
     return node;
@@ -1131,7 +1129,7 @@ namespace trieste
 
   inline Node operator<<(Node node, detail::RangeOr range_or)
   {
-    if (range_or.range.first != range_or.range.second)
+    if (!range_or.range.empty())
       node->push_back(range_or.range);
     else
       node->push_back(range_or.node);
@@ -1171,10 +1169,10 @@ namespace trieste
   inline Nodes clone(NodeRange range)
   {
     Nodes nodes;
-    nodes.reserve(std::distance(range.first, range.second));
+    nodes.reserve(range.size());
 
-    for (auto it = range.first; it != range.second; ++it)
-      nodes.push_back((*it)->clone());
+    for (Node n : range)
+      nodes.push_back(n->clone());
 
     return nodes;
   }

--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -1119,7 +1119,7 @@ namespace trieste
 
   inline Node operator<<(Node node, detail::RangeContents range_contents)
   {
-    for (Node n : range_contents.range)
+    for (Node& n : range_contents.range)
     {
       node->push_back({n->begin(), n->end()});
     }
@@ -1171,7 +1171,7 @@ namespace trieste
     Nodes nodes;
     nodes.reserve(range.size());
 
-    for (Node n : range)
+    for (const Node& n : range)
       nodes.push_back(n->clone());
 
     return nodes;

--- a/include/trieste/rewriter.h
+++ b/include/trieste/rewriter.h
@@ -79,5 +79,20 @@ namespace trieste
     {
       return debug_path_;
     }
+
+    const wf::Wellformed& input_wf() const
+    {
+      return *wf_;
+    }
+
+    const wf::Wellformed& output_wf() const
+    {
+      return passes_.back()->wf();
+    }
+
+    const std::vector<Pass>& passes() const
+    {
+      return passes_;
+    }
   };
 }

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -1074,6 +1074,22 @@ namespace trieste
             std::string(field.str()) + "`");
         }
       };
+
+    inline void new_context()
+    {
+      wf_current.push_back({});
+    }
+
+    inline void end_context()
+    {
+      if (wf_current.size() == 1)
+      {
+        logging::Error() << "Cannot end the base WF context" << std::endl;
+        return;
+      }
+
+      wf_current.pop_back();
+    }
     }
 
     inline const Wellformed empty;
@@ -1087,23 +1103,20 @@ namespace trieste
     {
       detail::wf_current.back().pop_front();
     }
-
-    inline void new_context()
-    {
-      detail::wf_current.push_back({});
-    }
-
-    inline void end_context()
-    {
-      if (detail::wf_current.size() == 1)
-      {
-        logging::Error() << "Cannot end the base WF context" << std::endl;
-        return;
-      }
-
-      detail::wf_current.pop_back();
-    }
   }
+
+  struct WFContext
+  {
+    WFContext()
+    {
+      wf::detail::new_context();
+    }
+
+    ~WFContext()
+    {
+      wf::detail::end_context();
+    }
+  };
 
   inline wf::detail::WFLookup operator/(const Node& node, const Token& field)
   {

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -32,6 +32,7 @@ namespace trieste
       GenNodeLocationF gloc;
       Rand rand;
       size_t target_depth;
+      size_t ceiling_depth;
       double alpha;
 
       /* The generator chooses which token to emit next. It makes this choice
@@ -53,11 +54,13 @@ namespace trieste
         GenNodeLocationF gloc_,
         Seed seed_,
         size_t target_depth_,
-        double alpha_ = 1)
+        double alpha_ = 1,
+        size_t ceiling_multiplier_ = 2)
       : token_terminal_distance(token_terminal_distance_),
         gloc(gloc_),
         rand(seed_),
         target_depth(target_depth_),
+        ceiling_depth(ceiling_multiplier_ * target_depth),
         alpha(alpha_)
       {}
 
@@ -103,6 +106,30 @@ namespace trieste
               throw std::runtime_error(err.str());
             }
           });
+
+        if (depth >= ceiling_depth)
+        {
+          // if we have reached this point P(c | d, p) as high entropy.
+          // In order to encourage termination, we will start to manually choose
+          // the child with the highest likelihood of terminating.
+          auto max = std::max_element(offsets.begin(), offsets.end());
+          return tokens[std::distance(offsets.begin(), max)];
+        }
+
+        if (depth >= 2 * ceiling_depth)
+        {
+          logging::Warn()
+            << "Token generation is not reaching a terminal after depth "
+            << depth;
+          logging::Warn()
+            << "This can indicate an issue with the WF definition (for "
+               "example, a cycle), or that the target depth is too shallow.";
+          logging::Trace() << "P(d | c, p):";
+          for (size_t i = 0; i < tokens.size(); i++)
+          {
+            logging::Trace() << "  " << tokens[i].str() << ": " << offsets[i];
+          }
+        }
 
         // compute the cumulative distribution of P(d | c, p)
         std::partial_sum(offsets.begin(), offsets.end(), offsets.begin());
@@ -1005,7 +1032,8 @@ namespace trieste
 
     namespace detail
     {
-      inline thread_local std::deque<const Wellformed*> wf_current;
+      using WFDeque = std::deque<const Wellformed*>;
+      inline thread_local std::vector<WFDeque> wf_current = {{}};
 
       struct WFLookup
       {
@@ -1052,18 +1080,34 @@ namespace trieste
 
     inline void push_back(const Wellformed& wf)
     {
-      detail::wf_current.push_back(&wf);
+      detail::wf_current.back().push_back(&wf);
     }
 
     inline void pop_front()
     {
-      detail::wf_current.pop_front();
+      detail::wf_current.back().pop_front();
+    }
+
+    inline void new_context()
+    {
+      detail::wf_current.push_back({});
+    }
+
+    inline void end_context()
+    {
+      if (detail::wf_current.size() == 1)
+      {
+        logging::Error() << "Cannot end the base WF context" << std::endl;
+        return;
+      }
+
+      detail::wf_current.pop_back();
     }
   }
 
   inline wf::detail::WFLookup operator/(const Node& node, const Token& field)
   {
-    for (auto wf : wf::detail::wf_current)
+    for (auto wf : wf::detail::wf_current.back())
     {
       if (!wf)
         continue;

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -1075,21 +1075,21 @@ namespace trieste
         }
       };
 
-    inline void new_context()
-    {
-      wf_current.push_back({});
-    }
-
-    inline void end_context()
-    {
-      if (wf_current.size() == 1)
+      inline void new_context()
       {
-        logging::Error() << "Cannot end the base WF context" << std::endl;
-        return;
+        wf_current.push_back({});
       }
 
-      wf_current.pop_back();
-    }
+      inline void end_context()
+      {
+        if (wf_current.size() == 1)
+        {
+          logging::Error() << "Cannot end the base WF context" << std::endl;
+          return;
+        }
+
+        wf_current.pop_back();
+      }
     }
 
     inline const Wellformed empty;
@@ -1112,9 +1112,32 @@ namespace trieste
       wf::detail::new_context();
     }
 
+    WFContext(const wf::Wellformed& wf) : WFContext()
+    {
+      push_back(wf);
+    }
+
+    WFContext(std::initializer_list<const wf::Wellformed*> wfs) : WFContext()
+    {
+      for (auto& wf : wfs)
+      {
+        push_back(*wf);
+      }
+    }
+
     ~WFContext()
     {
       wf::detail::end_context();
+    }
+
+    void push_back(const wf::Wellformed& wf)
+    {
+      wf::push_back(wf);
+    }
+
+    void pop_front()
+    {
+      wf::pop_front();
     }
   };
 

--- a/include/trieste/writer.h
+++ b/include/trieste/writer.h
@@ -223,9 +223,7 @@ namespace trieste
       }
 
       Destination dest = destination_;
-      WFContext context;
-      wf::push_back(*wf_);
-      wf::push_back(wf_writer);
+      WFContext context({wf_, &wf_writer});
 
       Nodes error_nodes;
       std::vector<Node> stack;
@@ -261,9 +259,6 @@ namespace trieste
           stack.insert(stack.end(), current->begin(), current->end());
         }
       }
-
-      wf::pop_front();
-      wf::pop_front();
 
       if (!error_nodes.empty())
       {

--- a/include/trieste/writer.h
+++ b/include/trieste/writer.h
@@ -223,6 +223,7 @@ namespace trieste
       }
 
       Destination dest = destination_;
+      wf::new_context();
       wf::push_back(*wf_);
       wf::push_back(wf_writer);
 
@@ -263,6 +264,7 @@ namespace trieste
 
       wf::pop_front();
       wf::pop_front();
+      wf::end_context();
 
       if (!error_nodes.empty())
       {
@@ -333,6 +335,16 @@ namespace trieste
     Destination destination() const
     {
       return destination_;
+    }
+
+    const wf::Wellformed& input_wf() const
+    {
+      return *wf_;
+    }
+
+    const std::vector<Pass>& passes() const
+    {
+      return passes_;
     }
   };
 }

--- a/include/trieste/writer.h
+++ b/include/trieste/writer.h
@@ -223,7 +223,7 @@ namespace trieste
       }
 
       Destination dest = destination_;
-      wf::new_context();
+      WFContext context;
       wf::push_back(*wf_);
       wf::push_back(wf_writer);
 
@@ -264,7 +264,6 @@ namespace trieste
 
       wf::pop_front();
       wf::pop_front();
-      wf::end_context();
 
       if (!error_nodes.empty())
       {

--- a/parsers/include/trieste/json.h
+++ b/parsers/include/trieste/json.h
@@ -12,19 +12,16 @@ namespace trieste
     using namespace wf::ops;
 
     inline const auto Value = TokenDef("json-value");
-    inline const auto Object = TokenDef("json-object");
+    inline const auto Object = TokenDef("json-object", flag::symtab);
     inline const auto Array = TokenDef("json-array");
     inline const auto String = TokenDef("json-string", flag::print);
     inline const auto Number = TokenDef("json-number", flag::print);
     inline const auto True = TokenDef("json-true");
     inline const auto False = TokenDef("json-false");
     inline const auto Null = TokenDef("json-null");
-    inline const auto Member = TokenDef("json-member");
+    inline const auto Member = TokenDef("json-member", flag::lookdown);
     inline const auto ErrorSeq = TokenDef("json-errorseq");
-    inline const auto Comma = TokenDef("json-comma");
-    inline const auto Colon = TokenDef("json-colon");
-    inline const auto Lhs = TokenDef("json-lhs");
-    inline const auto Rhs = TokenDef("json-rhs");
+    inline const auto Key = TokenDef("json-key", flag::print);
 
     // groups
     inline const auto ArrayGroup = TokenDef("json-array-group");
@@ -37,7 +34,7 @@ namespace trieste
     inline const auto wf =
       (Top <<= wf_value_tokens++[1])
       | (Object <<= Member++)
-      | (Member <<= String * (Value >>= wf_value_tokens))
+      | (Member <<= Key * (Value >>= wf_value_tokens))[Key]
       | (Array <<= wf_value_tokens++)
       ;
     // clang-format on
@@ -46,9 +43,15 @@ namespace trieste
     Writer writer(
       const std::filesystem::path& path,
       bool prettyprint = false,
+      bool sort_keys = false,
       const std::string& indent = "  ");
     std::string to_string(
-      Node json, bool prettyprint = false, const std::string& indent = "  ");
+      Node json,
+      bool prettyprint = false,
+      bool sort_keys = false,
+      const std::string& indent = "  ");
     bool equal(Node lhs_json, Node rhs_json);
+    std::string unescape(const std::string_view& string);
+    std::string escape(const std::string_view& string);
   }
 }

--- a/parsers/include/trieste/json.h
+++ b/parsers/include/trieste/json.h
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "trieste/token.h"
 #include "trieste/trieste.h"
 
 namespace trieste

--- a/parsers/include/trieste/yaml.h
+++ b/parsers/include/trieste/yaml.h
@@ -13,124 +13,60 @@ namespace trieste
 
     inline const auto Stream =
       TokenDef("yaml-stream", flag::symtab | flag::defbeforeuse);
-    inline const auto Document =
-      TokenDef("yaml-document", flag::symtab | flag::defbeforeuse);
-    inline const auto Documents = TokenDef("yaml-documents");
-    inline const auto Sequence = TokenDef("yaml-sequence");
-    inline const auto SequenceItem = TokenDef("yaml-sequenceitem");
-    inline const auto Mapping = TokenDef("yaml-mapping");
-    inline const auto MappingItem = TokenDef("yaml-mappingitem");
-    inline const auto MappingValue = TokenDef("yaml-mappingvalue");
-    inline const auto Value = TokenDef("yaml-value", flag::print);
+    inline const auto Directives = TokenDef("yaml-directives");
     inline const auto UnknownDirective =
       TokenDef("yaml-unknowndirective", flag::print);
     inline const auto VersionDirective =
       TokenDef("yaml-versiondirective", flag::print);
     inline const auto TagDirective =
       TokenDef("yaml-tagdirective", flag::lookup | flag::shadowing);
-    inline const auto MaybeDirective =
-      TokenDef("yaml-maybedirective", flag::print);
-    inline const auto Directives = TokenDef("yaml-directives");
     inline const auto TagPrefix = TokenDef("yaml-tagprefix", flag::print);
     inline const auto TagHandle = TokenDef("yaml-taghandle", flag::print);
-    inline const auto NonSpecificTag =
-      TokenDef("yaml-nonspecifictag", flag::print);
-    inline const auto VerbatimTag = TokenDef("yaml-verbatimtag", flag::print);
-    inline const auto ShorthandTag = TokenDef("yaml-shorthandtag", flag::print);
-    inline const auto Tag = TokenDef("yaml-tag");
-    inline const auto TagValue = TokenDef("yaml-tagvalue");
-    inline const auto TagName = TokenDef("yaml-tagname", flag::print);
+    inline const auto Documents = TokenDef("yaml-documents");
+    inline const auto Document =
+      TokenDef("yaml-document", flag::symtab | flag::defbeforeuse);
+    inline const auto DocumentStart = TokenDef("yaml-docstart", flag::print);
+    inline const auto DocumentEnd = TokenDef("yaml-docend", flag::print);
+    inline const auto Sequence = TokenDef("yaml-sequence");
+    inline const auto Mapping = TokenDef("yaml-mapping");
+    inline const auto MappingItem = TokenDef("yaml-mappingitem");
+    inline const auto Key = TokenDef("yaml-key");
+    inline const auto Value = TokenDef("yaml-value", flag::print);
     inline const auto Int = TokenDef("yaml-int", flag::print);
     inline const auto Hex = TokenDef("yaml-hex", flag::print);
     inline const auto Float = TokenDef("yaml-float", flag::print);
-    inline const auto String = TokenDef("yaml-string", flag::print);
-    inline const auto ErrorSeq = TokenDef("yaml-error-seq");
-    inline const auto Key = TokenDef("yaml-key");
-    inline const auto KeyItem = TokenDef("yaml-keyitem", flag::print);
-    inline const auto Alias = TokenDef("yaml-alias", flag::print);
-    inline const auto Anchor = TokenDef("yaml-anchor", flag::print);
-    inline const auto AnchorValue = TokenDef("yaml-anchorvalue", flag::lookup);
-    inline const auto SingleQuote = TokenDef("yaml-singlequote");
-    inline const auto DoubleQuote = TokenDef("yaml-doublequote");
-    inline const auto DocumentStart = TokenDef("yaml-docstart", flag::print);
-    inline const auto DocumentEnd = TokenDef("yaml-docend", flag::print);
-    inline const auto Whitespace = TokenDef("yaml-whitespace", flag::print);
-    inline const auto Hyphen = TokenDef("yaml-hyphen");
-    inline const auto Colon = TokenDef("yaml-colon");
-    inline const auto Comma = TokenDef("yaml-comma");
-    inline const auto NewLine = TokenDef("yaml-newline");
-    inline const auto Literal = TokenDef("yaml-literal");
-    inline const auto Folded = TokenDef("yaml-folded");
-    inline const auto Comment = TokenDef("yaml-comment", flag::print);
-    inline const auto Plain = TokenDef("yaml-plain");
-    inline const auto IndentIndicator =
-      TokenDef("yaml-indentation-indicator", flag::print);
-    inline const auto ChompIndicator =
-      TokenDef("yaml-chomp-indicator", flag::print);
-    inline const auto Lines = TokenDef("yaml-lines");
-    inline const auto BlockLine = TokenDef("yaml-blockline", flag::print);
-    inline const auto Empty = TokenDef("yaml-empty");
     inline const auto Null = TokenDef("yaml-null");
     inline const auto True = TokenDef("yaml-true");
     inline const auto False = TokenDef("yaml-false");
-    inline const auto Flow = TokenDef("yaml-flow");
-    inline const auto FlowMapping = TokenDef("yaml-flowmapping");
-    inline const auto FlowMappingItem = TokenDef("yaml-flowmappingitem");
-    inline const auto FlowMappingItems = TokenDef("yaml-flowmappingitems");
-    inline const auto FlowSequence = TokenDef("yaml-flowsequence");
-    inline const auto FlowSequenceItem = TokenDef("yaml-flowsequenceitem");
-    inline const auto FlowSequenceItems = TokenDef("yaml-flowsequenceitems");
-    inline const auto FlowItem = TokenDef("yaml-flowitem", flag::print);
-    inline const auto FlowEmpty = TokenDef("yaml-flowempty", flag::print);
-    inline const auto FlowKeyEnd = TokenDef("yaml-flowkeyend");
-    inline const auto FlowKeyValue = TokenDef("yaml-flowkeyvalue", flag::print);
-    inline const auto FlowSequenceStart =
-      TokenDef("yaml-flowseqstart", flag::print);
-    inline const auto FlowSequenceEnd =
-      TokenDef("yaml-flowseqend", flag::print);
-    inline const auto FlowMappingStart =
-      TokenDef("yaml-flowmapstart", flag::print);
-    inline const auto FlowMappingEnd = TokenDef("yaml-flowmapend", flag::print);
-    inline const auto Lhs = TokenDef("yaml-lhs");
-    inline const auto Rhs = TokenDef("yaml-rhs");
+    inline const auto SingleQuote = TokenDef("yaml-singlequote");
+    inline const auto DoubleQuote = TokenDef("yaml-doublequote");
+    inline const auto BlockLine = TokenDef("yaml-blockline", flag::print);
+    inline const auto EmptyLine = TokenDef("yaml-emptyline");
+    inline const auto Literal = TokenDef("yaml-literal");
+    inline const auto Folded = TokenDef("yaml-folded");
     inline const auto AbsoluteIndent =
       TokenDef("yaml-absoluteindent", flag::print);
-    inline const auto Indent = TokenDef("yaml-indent");
-    inline const auto Head = TokenDef("yaml-head");
-    inline const auto Tail = TokenDef("yaml-tail");
-    inline const auto EmptyLine = TokenDef("yaml-emptyline");
-    inline const auto WhitespaceLine =
-      TokenDef("yaml-whitespace-line", flag::print);
-    inline const auto Block = TokenDef("yaml-block");
-    inline const auto Line = TokenDef("yaml-line");
-    inline const auto Extra = TokenDef("yaml-extra");
-    inline const auto ComplexKey = TokenDef("yaml-complexkey");
-    inline const auto ComplexValue = TokenDef("yaml-complexvalue");
-    inline const auto BlockIndent = TokenDef("yaml-blockindent");
-    inline const auto ManualIndent = TokenDef("yaml-manualindent");
-    inline const auto SequenceIndent = TokenDef("yaml-sequenceindent");
-    inline const auto MappingIndent = TokenDef("yaml-mappingindent");
-    inline const auto Placeholder = TokenDef("yaml-placeholder");
-    inline const auto BlockStart = TokenDef("yaml-blockstart");
-
-    // groups
-    inline const auto StreamGroup = TokenDef("yaml-streamgroup");
-    inline const auto DocumentGroup = TokenDef("yaml-documentgroup");
-    inline const auto TagGroup = TokenDef("yaml-taggroup");
-    inline const auto FlowGroup = TokenDef("yaml-flowgroup");
-    inline const auto TagDirectiveGroup = TokenDef("yaml-tagdirectivegroup");
-    inline const auto KeyGroup = TokenDef("yaml-keygroup");
-    inline const auto ValueGroup = TokenDef("yaml-valuegroup");
-    inline const auto BlockGroup = TokenDef("yaml-blockgroup");
-    inline const auto SequenceGroup = TokenDef("yaml-sequencegroup");
-    inline const auto MappingGroup = TokenDef("yaml-mappinggroup");
+    inline const auto ChompIndicator =
+      TokenDef("yaml-chomp-indicator", flag::print);
+    inline const auto Lines = TokenDef("yaml-lines");
+    inline const auto Plain = TokenDef("yaml-plain");
+    inline const auto AnchorValue = TokenDef("yaml-anchorvalue", flag::lookup);
+    inline const auto Anchor = TokenDef("yaml-anchor", flag::print);
+    inline const auto TagValue = TokenDef("yaml-tagvalue");
+    inline const auto TagName = TokenDef("yaml-tagname", flag::print);
+    inline const auto Alias = TokenDef("yaml-alias", flag::print);
+    inline const auto Empty = TokenDef("yaml-empty");
+    inline const auto FlowMapping = TokenDef("yaml-flowmapping");
+    inline const auto FlowMappingItem = TokenDef("yaml-flowmappingitem");
+    inline const auto FlowSequence = TokenDef("yaml-flowsequence");
 
     inline const auto wf_tokens = Mapping | Sequence | Value | Int | Float |
       True | False | Hex | Null | SingleQuote | DoubleQuote | Plain |
       AnchorValue | Alias | TagValue | Literal | Folded | Empty | FlowMapping |
       FlowSequence;
 
-    inline const auto wf_flow_tokens = wf_tokens - (Mapping | Sequence);
+    inline const auto wf_flow_tokens =
+      wf_tokens - (Literal | Folded | Mapping | Sequence);
 
     // clang-format off
     inline const auto wf =

--- a/parsers/include/trieste/yaml.h
+++ b/parsers/include/trieste/yaml.h
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#include "trieste/token.h"
 #include "trieste/trieste.h"
 
 namespace trieste

--- a/parsers/json/CMakeLists.txt
+++ b/parsers/json/CMakeLists.txt
@@ -4,7 +4,11 @@ reader.cc
 writer.cc
 )
 
-add_library(json STATIC ${SOURCES})
+if( BUILD_SHARED_LIBS )
+  add_library(json SHARED ${SOURCES})
+else()
+  add_library(json STATIC ${SOURCES})
+endif()
 
 add_library(trieste::json ALIAS json)
 

--- a/parsers/json/internal.h
+++ b/parsers/json/internal.h
@@ -6,6 +6,11 @@ namespace trieste
 {
   namespace json
   {
+    inline const auto Comma = TokenDef("json-comma");
+    inline const auto Colon = TokenDef("json-colon");
+    inline const auto Lhs = TokenDef("json-lhs");
+    inline const auto Rhs = TokenDef("json-rhs");
+
     Parse parser();
 
     inline const auto wf_parse_tokens =

--- a/parsers/json/reader.cc
+++ b/parsers/json/reader.cc
@@ -15,7 +15,7 @@ namespace
       if (n->type() == Error)
         return false;
 
-      for (auto child : *n)
+      for (Node& child : *n)
       {
         if (token_messages.count(child->type()) > 0)
         {

--- a/parsers/json/reader.cc
+++ b/parsers/json/reader.cc
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "trieste/utf8.h"
 
 namespace
 {
@@ -142,13 +143,12 @@ namespace
             (T(File) << ((T(Group) << (ValueToken++[Value] * End)) * End)) >>
           [allow_multiple](Match& _) {
             auto values = _[Value];
-            if (values.first == values.second)
+            if (values.empty())
             {
               return err("Invalid JSON");
             }
 
-            if (
-              std::distance(values.first, values.second) > 1 && !allow_multiple)
+            if (values.size() > 1 && !allow_multiple)
             {
               return err("Multiple top-level values not allowed");
             }
@@ -188,13 +188,21 @@ namespace
 
         In(ObjectGroup) *
             (Start * T(String)[Lhs] * T(Colon) * ValueToken[Rhs]) >>
-          [](Match& _) { return (Member << _(Lhs) << _(Rhs)); },
+          [](Match& _) {
+            Location key = _(Lhs)->location();
+            key.pos += 1;
+            key.len -= 2;
+            return (Member << (Key ^ key) << _(Rhs));
+          },
 
         In(ObjectGroup) *
             (T(Member)[Member] * T(Comma) * T(String)[Lhs] * T(Colon) *
              ValueToken[Rhs]) >>
           [](Match& _) {
-            return Seq << _(Member) << (Member << _(Lhs) << _(Rhs));
+            Location key = _(Lhs)->location();
+            key.pos += 1;
+            key.len -= 2;
+            return Seq << _(Member) << (Member << (Key ^ key) << _(Rhs));
           },
 
         In(Object) * (T(ObjectGroup) << (T(Member)++[Object] * End)) >>
@@ -222,6 +230,102 @@ namespace trieste
     bool equal(Node lhs, Node rhs)
     {
       return value_equal(lhs, rhs);
+    }
+
+    std::string unescape(const std::string_view& string)
+    {
+      std::string temp = utf8::unescape_hexunicode(string);
+      std::string result;
+      result.reserve(temp.size());
+      for (auto it = temp.begin(); it != temp.end(); ++it)
+      {
+        if (*it == '\\')
+        {
+          it++;
+          switch (*it)
+          {
+            case 'b':
+              result.push_back('\b');
+              break;
+
+            case 'f':
+              result.push_back('\f');
+              break;
+
+            case 'n':
+              result.push_back('\n');
+              break;
+
+            case 'r':
+              result.push_back('\r');
+              break;
+
+            case 't':
+              result.push_back('\t');
+              break;
+
+            case '\\':
+            case '/':
+            case '"':
+              result.push_back(*it);
+              break;
+
+            default:
+              throw std::runtime_error("Invalid escape sequence");
+          }
+        }
+        else
+        {
+          result.push_back(*it);
+        }
+      }
+
+      return result;
+    }
+
+    std::string escape(const std::string_view& string)
+    {
+      std::string temp = utf8::escape_unicode(string);
+      std::ostringstream buf;
+      for (auto it = temp.begin(); it != temp.end(); ++it)
+      {
+        switch (*it)
+        {
+          case '\b':
+            buf << '\\' << 'b';
+            break;
+
+          case '\f':
+            buf << '\\' << 'f';
+            break;
+
+          case '\n':
+            buf << '\\' << 'n';
+            break;
+
+          case '\r':
+            buf << '\\' << 'r';
+            break;
+
+          case '\t':
+            buf << '\\' << 't';
+            break;
+
+          case '\\':
+            buf << '\\' << '\\';
+            break;
+
+          case '"':
+            buf << '\\' << '"';
+            break;
+
+          default:
+            buf << *it;
+            break;
+        }
+      }
+
+      return buf.str();
     }
   }
 }

--- a/parsers/json/writer.cc
+++ b/parsers/json/writer.cc
@@ -230,11 +230,9 @@ namespace trieste
     std::string to_string(
       Node json, bool prettyprint, bool sort_keys, const std::string& indent)
     {
-      WFContext context;
-      wf::push_back(json::wf);
+      WFContext context(json::wf);
       std::ostringstream os;
       write_value(os, {prettyprint, sort_keys, indent}, "", json);
-      wf::pop_front();
       return os.str();
     }
   }

--- a/parsers/json/writer.cc
+++ b/parsers/json/writer.cc
@@ -230,12 +230,11 @@ namespace trieste
     std::string to_string(
       Node json, bool prettyprint, bool sort_keys, const std::string& indent)
     {
-      wf::new_context();
+      WFContext context;
       wf::push_back(json::wf);
       std::ostringstream os;
       write_value(os, {prettyprint, sort_keys, indent}, "", json);
       wf::pop_front();
-      wf::end_context();
       return os.str();
     }
   }

--- a/parsers/json/writer.cc
+++ b/parsers/json/writer.cc
@@ -218,7 +218,7 @@ namespace trieste
         {to_file(path)},
         json::wf,
         [prettyprint, sort_keys, indent](std::ostream& os, Node contents) {
-          for (Node value : *contents)
+          for (const Node& value : *contents)
           {
             write_value(os, {prettyprint, sort_keys, indent}, "", value);
             os << std::endl;

--- a/parsers/json/writer.cc
+++ b/parsers/json/writer.cc
@@ -9,6 +9,7 @@ namespace
   struct WriteSettings
   {
     bool prettyprint;
+    bool sort_keys;
     const std::string& indent;
   };
 
@@ -36,36 +37,64 @@ namespace
     {
       os << std::endl;
     }
-    for (std::size_t i = 0; i < object->size(); ++i)
+
+    std::vector<Node> members;
+    if (settings.sort_keys)
     {
-      Node member = object->at(i);
+      std::vector<Location> keys;
+      std::transform(
+        object->begin(),
+        object->end(),
+        std::back_inserter(keys),
+        [](Node member) { return (member / Key)->location(); });
+      std::sort(keys.begin(), keys.end());
+      for (const Location& key : keys)
+      {
+        Nodes defs = object->lookdown(key);
+        members.insert(members.end(), defs.begin(), defs.end());
+      }
+    }
+    else
+    {
+      members.insert(members.end(), object->begin(), object->end());
+    }
+
+    for (std::size_t i = 0; i < members.size(); ++i)
+    {
+      Node member = members[i];
       assert(member == Member);
+
       if (settings.prettyprint)
       {
         os << new_indent;
       }
 
-      write_value(os, settings, new_indent, member / String);
+      write_value(os, settings, new_indent, member / Key);
       os << ":";
+
       if (settings.prettyprint)
       {
         os << " ";
       }
+
       write_value(os, settings, new_indent, member / Value);
 
       if (i < object->size() - 1)
       {
         os << ",";
       }
+
       if (settings.prettyprint)
       {
         os << std::endl;
       }
     }
+
     if (settings.prettyprint)
     {
       os << indent;
     }
+
     os << "}";
   }
 
@@ -123,6 +152,10 @@ namespace
     {
       os << value->location().view();
     }
+    else if (value == Key)
+    {
+      os << '"' << value->location().view() << '"';
+    }
     else if (value == Object)
     {
       write_object(os, settings, indent, value);
@@ -177,29 +210,32 @@ namespace trieste
     Writer writer(
       const std::filesystem::path& path,
       bool prettyprint,
+      bool sort_keys,
       const std::string& indent)
     {
       return Writer(
         "json",
         {to_file(path)},
         json::wf,
-        [prettyprint, indent](std::ostream& os, Node contents) {
+        [prettyprint, sort_keys, indent](std::ostream& os, Node contents) {
           for (Node value : *contents)
           {
-            write_value(os, {prettyprint, indent}, "", value);
+            write_value(os, {prettyprint, sort_keys, indent}, "", value);
             os << std::endl;
           }
           return true;
         });
     }
 
-    std::string
-    to_string(Node json, bool prettyprint, const std::string& indent)
+    std::string to_string(
+      Node json, bool prettyprint, bool sort_keys, const std::string& indent)
     {
+      wf::new_context();
       wf::push_back(json::wf);
       std::ostringstream os;
-      write_value(os, {prettyprint, indent}, "", json);
+      write_value(os, {prettyprint, sort_keys, indent}, "", json);
       wf::pop_front();
+      wf::end_context();
       return os.str();
     }
   }

--- a/parsers/test/CMakeLists.txt
+++ b/parsers/test/CMakeLists.txt
@@ -36,10 +36,10 @@ target_link_libraries(yaml_test
 
 set(YAML_TEST_SUITE_ROOT ${CMAKE_CURRENT_BINARY_DIR}/../yaml-test-suite)
 
-add_test(NAME yaml_fuzzer_reader COMMAND yaml_fuzzer reader -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
-add_test(NAME yaml_fuzzer_writer COMMAND yaml_fuzzer writer -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
-add_test(NAME yaml_fuzzer_event_writer COMMAND yaml_fuzzer event_writer -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
-add_test(NAME yaml_fuzzer_to_json COMMAND yaml_fuzzer to_json -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
+add_test(NAME yaml_fuzz_reader COMMAND yaml_fuzzer reader -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
+add_test(NAME yaml_fuzz_writer COMMAND yaml_fuzzer writer -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
+add_test(NAME yaml_fuzz_event_writer COMMAND yaml_fuzzer event_writer -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
+add_test(NAME yaml_fuzz_to_json COMMAND yaml_fuzzer to_json -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
 add_test(NAME yaml_test COMMAND yaml_test -wf ${YAML_TEST_SUITE_ROOT} WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_test>)
 add_test(NAME yaml_test_crlf COMMAND yaml_test --crlf -wf ${YAML_TEST_SUITE_ROOT} WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_test>)
 

--- a/parsers/test/CMakeLists.txt
+++ b/parsers/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 ## JSON
 
-add_executable(json_trieste json_trieste.cc)
+add_executable(json_fuzzer json_fuzzer.cc)
 
-target_link_libraries(json_trieste
+target_link_libraries(json_fuzzer
   PRIVATE
   trieste::json)
 
@@ -14,16 +14,17 @@ target_link_libraries(json_test
 
 set(JSON_TEST_SUITE_ROOT ${CMAKE_CURRENT_BINARY_DIR}/../JSONTestSuite/test_parsing)
 
-add_test(NAME json_trieste COMMAND json_trieste test -f WORKING_DIRECTORY $<TARGET_FILE_DIR:json_trieste>)
+add_test(NAME json_fuzz_reader COMMAND json_fuzzer reader -f WORKING_DIRECTORY $<TARGET_FILE_DIR:json_fuzzer>)
+add_test(NAME json_fuzz_writer COMMAND json_fuzzer writer -f WORKING_DIRECTORY $<TARGET_FILE_DIR:json_fuzzer>)
 add_test(NAME json_test COMMAND json_test -wf ${JSON_TEST_SUITE_ROOT} WORKING_DIRECTORY $<TARGET_FILE_DIR:json_test>)
 
-install(TARGETS json_trieste json_test RUNTIME DESTINATION parsers)
+install(TARGETS json_fuzzer json_test RUNTIME DESTINATION parsers)
 
 ## YAML
 
-add_executable(yaml_trieste yaml_trieste.cc)
+add_executable(yaml_fuzzer yaml_fuzzer.cc)
 
-target_link_libraries(yaml_trieste
+target_link_libraries(yaml_fuzzer
   PRIVATE
   trieste::yaml)
 
@@ -35,8 +36,11 @@ target_link_libraries(yaml_test
 
 set(YAML_TEST_SUITE_ROOT ${CMAKE_CURRENT_BINARY_DIR}/../yaml-test-suite)
 
-add_test(NAME yaml_trieste COMMAND yaml_trieste test -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_trieste>)
+add_test(NAME yaml_fuzzer_reader COMMAND yaml_fuzzer reader -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
+add_test(NAME yaml_fuzzer_writer COMMAND yaml_fuzzer writer -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
+add_test(NAME yaml_fuzzer_event_writer COMMAND yaml_fuzzer event_writer -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
+add_test(NAME yaml_fuzzer_to_json COMMAND yaml_fuzzer to_json -f WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_fuzzer>)
 add_test(NAME yaml_test COMMAND yaml_test -wf ${YAML_TEST_SUITE_ROOT} WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_test>)
 add_test(NAME yaml_test_crlf COMMAND yaml_test --crlf -wf ${YAML_TEST_SUITE_ROOT} WORKING_DIRECTORY $<TARGET_FILE_DIR:yaml_test>)
 
-install(TARGETS yaml_trieste yaml_test RUNTIME DESTINATION parsers)
+install(TARGETS yaml_fuzzer yaml_test RUNTIME DESTINATION parsers)

--- a/parsers/test/json_fuzzer.cc
+++ b/parsers/test/json_fuzzer.cc
@@ -1,0 +1,61 @@
+#include <CLI/CLI.hpp>
+#include <trieste/fuzzer.h>
+#include <trieste/json.h>
+
+using namespace trieste;
+
+int main(int argc, char** argv)
+{
+  CLI::App app;
+
+  app.set_help_all_flag("--help-all", "Expand all help");
+
+  std::string transform;
+  app.add_option("transform", transform, "Transform to test")
+    ->check(CLI::IsMember({"reader", "writer"}))
+    ->required(true);
+
+  uint32_t seed = std::random_device()();
+  app.add_option("-s,--seed", seed, "Random seed");
+
+  uint32_t count = 100;
+  app.add_option("-c,--count", count, "Number of seed to test");
+
+  bool failfast = false;
+  app.add_flag("-f,--failfast", failfast, "Stop on first failure");
+
+  std::string log_level;
+  app
+    .add_option(
+      "-l,--log_level",
+      log_level,
+      "Set Log Level to one of "
+      "Trace, Debug, Info, "
+      "Warning, Output, Error, "
+      "None")
+    ->check(logging::set_log_level_from_string);
+
+  try
+  {
+    app.parse(argc, argv);
+  }
+  catch (const CLI::ParseError& e)
+  {
+    return app.exit(e);
+  }
+
+  logging::Output() << "Testing x" << count << ", seed: " << seed << std::endl;
+
+  Fuzzer fuzzer;
+  Reader reader = json::reader();
+  if (transform == "reader")
+  {
+    fuzzer = Fuzzer(reader);
+  }
+  else
+  {
+    fuzzer = Fuzzer(json::writer("fuzzer"), reader.parser().generators());
+  }
+
+  return fuzzer.start_seed(seed).seed_count(count).failfast(failfast).test();
+}

--- a/parsers/test/json_test.cc
+++ b/parsers/test/json_test.cc
@@ -259,14 +259,16 @@ struct TestCase
   {
     if (std::filesystem::is_directory(file_or_dir))
     {
-      for (auto& path : std::filesystem::directory_iterator(file_or_dir))
+      const std::filesystem::path dir_path = file_or_dir;
+      auto dir_iter = std::filesystem::directory_iterator{dir_path};
+      for(auto it = std::filesystem::begin(dir_iter); it != std::filesystem::end(dir_iter); ++it)
       {
-        load(test_cases, path);
+        load(test_cases, it->path());
       }
     }
     else
     {
-      std::filesystem::path file = file_or_dir;
+      const std::filesystem::path file = file_or_dir;
       if (file.extension() == ".json")
       {
         std::string json = utf8::read_to_end(file, true);

--- a/parsers/test/json_trieste.cc
+++ b/parsers/test/json_trieste.cc
@@ -1,7 +1,0 @@
-#include <trieste/driver.h>
-#include <trieste/json.h>
-
-int main(int argc, char** argv)
-{
-  trieste::Driver(trieste::json::reader()).run(argc, argv);
-}

--- a/parsers/test/yaml_fuzzer.cc
+++ b/parsers/test/yaml_fuzzer.cc
@@ -1,0 +1,71 @@
+#include "trieste/logging.h"
+
+#include <CLI/CLI.hpp>
+#include <trieste/fuzzer.h>
+#include <trieste/yaml.h>
+
+using namespace trieste;
+
+int main(int argc, char** argv)
+{
+  CLI::App app;
+
+  app.set_help_all_flag("--help-all", "Expand all help");
+
+  std::string transform;
+  app.add_option("transform", transform, "Transform to test")
+    ->check(CLI::IsMember({"reader", "writer", "event_writer", "to_json"}))
+    ->required(true);
+
+  uint32_t seed = std::random_device()();
+  app.add_option("-s,--seed", seed, "Random seed");
+
+  uint32_t count = 100;
+  app.add_option("-c,--count", count, "Number of seed to test");
+
+  bool failfast = false;
+  app.add_flag("-f,--failfast", failfast, "Stop on first failure");
+
+  std::string log_level;
+  app
+    .add_option(
+      "-l,--log_level",
+      log_level,
+      "Set Log Level to one of "
+      "Trace, Debug, Info, "
+      "Warning, Output, Error, "
+      "None")
+    ->check(logging::set_log_level_from_string);
+
+  try
+  {
+    app.parse(argc, argv);
+  }
+  catch (const CLI::ParseError& e)
+  {
+    return app.exit(e);
+  }
+
+  logging::Output() << "Testing x" << count << ", seed: " << seed << std::endl;
+
+  Fuzzer fuzzer;
+  Reader reader = yaml::reader();
+  if (transform == "reader")
+  {
+    fuzzer = Fuzzer(reader);
+  }
+  else if (transform == "writer")
+  {
+    fuzzer = Fuzzer(yaml::writer("fuzzer"), reader.parser().generators());
+  }
+  else if (transform == "event_writer")
+  {
+    fuzzer = Fuzzer(yaml::event_writer("fuzzer"), reader.parser().generators());
+  }
+  else if (transform == "to_json")
+  {
+    fuzzer = Fuzzer(yaml::to_json(), reader.parser().generators());
+  }
+
+  return fuzzer.start_seed(seed).seed_count(count).failfast(failfast).test();
+}

--- a/parsers/test/yaml_test.cc
+++ b/parsers/test/yaml_test.cc
@@ -570,8 +570,11 @@ int main(int argc, char* argv[])
   {
     if (std::filesystem::is_directory(path))
     {
-      for (auto& file_or_dir : std::filesystem::directory_iterator(path))
+      const std::filesystem::path dir_path = path;
+      auto dir_iter = std::filesystem::directory_iterator{dir_path};
+      for(auto it = std::filesystem::begin(dir_iter); it != std::filesystem::end(dir_iter); ++it)
       {
+        const std::filesystem::path file_or_dir = it->path();
         if (std::filesystem::is_directory(file_or_dir))
         {
           TestCase::load(test_cases, file_or_dir, crlf);
@@ -579,7 +582,7 @@ int main(int argc, char* argv[])
         else
         {
           trieste::logging::Error()
-            << "Not a directory: " << file_or_dir.path();
+            << "Not a directory: " << file_or_dir;
           return 1;
         }
       }

--- a/parsers/test/yaml_trieste.cc
+++ b/parsers/test/yaml_trieste.cc
@@ -1,7 +1,0 @@
-#include <trieste/driver.h>
-#include <trieste/yaml.h>
-
-int main(int argc, char** argv)
-{
-  trieste::Driver(trieste::yaml::reader()).run(argc, argv);
-}

--- a/parsers/yaml/CMakeLists.txt
+++ b/parsers/yaml/CMakeLists.txt
@@ -6,7 +6,11 @@ reader.cc
 to_json.cc
 )
 
-add_library(yaml STATIC ${SOURCES})
+if( BUILD_SHARED_LIBS )
+  add_library(yaml SHARED ${SOURCES})
+else()
+  add_library(yaml STATIC ${SOURCES})
+endif()
 
 add_library(trieste::yaml ALIAS yaml)
 

--- a/parsers/yaml/CMakeLists.txt
+++ b/parsers/yaml/CMakeLists.txt
@@ -20,13 +20,6 @@ target_link_libraries(yaml
     trieste::json
 )
 
-add_executable(yamlc yamlc.cc)
-
-target_link_libraries(yamlc
-  PRIVATE
-    yaml
-)
-
 if(MSVC)
   target_compile_options(yaml PUBLIC "/Zc:__cplusplus")
   target_compile_definitions(yaml PUBLIC "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING")
@@ -58,4 +51,13 @@ install(TARGETS yaml
 
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../include/trieste/yaml.h DESTINATION include/trieste)
 
-install(TARGETS yamlc RUNTIME DESTINATION parsers)
+if( TRIESTE_BUILD_PARSER_TOOLS )
+  add_executable(yamlc yamlc.cc)
+
+  target_link_libraries(yamlc
+    PRIVATE
+      yaml
+  )
+
+  install(TARGETS yamlc RUNTIME DESTINATION parsers)
+endif()

--- a/parsers/yaml/README.md
+++ b/parsers/yaml/README.md
@@ -49,8 +49,8 @@ The language implementation exposes the following helpers:
 
 ## Using the `yamlc` Executable
 
-One of the targets that will be written to the `dist/parsers` directory is an executable named `yamlc`. It
-has the following usage information:
+One of the targets that will be written to the `dist/parsers` directory is an executable named `yamlc` (which will
+only be built if the `TRIESTE_BUILD_PARSER_TOOLS` flag is set). It has the following usage information:
 
 ```
 Usage: parsers/yamlc [OPTIONS] input [output]

--- a/parsers/yaml/event_writer.cc
+++ b/parsers/yaml/event_writer.cc
@@ -99,7 +99,7 @@ namespace
     Node node = handle_tag_anchor(os, maybe_node);
 
     os << newline;
-    for (auto child : *node)
+    for (const Node& child : *node)
     {
       if (write_event(os, newline, child))
       {
@@ -126,7 +126,7 @@ namespace
     Node node = handle_tag_anchor(os, maybe_node);
 
     os << newline;
-    for (auto child : *node)
+    for (const Node& child : *node)
     {
       if (write_event(os, newline, child))
       {
@@ -323,7 +323,7 @@ namespace
     if (node_type == Stream)
     {
       os << "+STR" << newline;
-      for (Node child : *node->back())
+      for (const Node& child : *node->back())
       {
         if (write_event(os, newline, child))
         {
@@ -453,7 +453,7 @@ namespace trieste
       }
 
       std::vector<std::string_view> lines;
-      for (auto line_node : *lines_node)
+      for (const Node& line_node : *lines_node)
       {
         auto view = line_node->location().view();
         auto maybe_comment = view.find('#');

--- a/parsers/yaml/event_writer.cc
+++ b/parsers/yaml/event_writer.cc
@@ -652,7 +652,7 @@ namespace trieste
       else
       {
         auto last = node->back()->location().view();
-        if (last.empty())
+        if (last.empty() && node->size() > 1)
         {
           os << " ";
         }

--- a/parsers/yaml/internal.h
+++ b/parsers/yaml/internal.h
@@ -27,6 +27,29 @@ namespace trieste
       const std::string_view& find,
       const std::string_view& replace);
 
+    inline const auto Whitespace = TokenDef("yaml-whitespace", flag::print);
+    inline const auto Hyphen = TokenDef("yaml-hyphen");
+    inline const auto Colon = TokenDef("yaml-colon");
+    inline const auto Comma = TokenDef("yaml-comma");
+    inline const auto NewLine = TokenDef("yaml-newline");
+    inline const auto Comment = TokenDef("yaml-comment", flag::print);
+    inline const auto VerbatimTag = TokenDef("yaml-verbatimtag", flag::print);
+    inline const auto ShorthandTag = TokenDef("yaml-shorthandtag", flag::print);
+    inline const auto Tag = TokenDef("yaml-tag");
+    inline const auto IndentIndicator =
+      TokenDef("yaml-indentation-indicator", flag::print);
+    inline const auto FlowSequenceStart =
+      TokenDef("yaml-flowseqstart", flag::print);
+    inline const auto FlowSequenceEnd =
+      TokenDef("yaml-flowseqend", flag::print);
+    inline const auto FlowMappingStart =
+      TokenDef("yaml-flowmapstart", flag::print);
+    inline const auto FlowMappingEnd = TokenDef("yaml-flowmapend", flag::print);
+    inline const auto MaybeDirective =
+      TokenDef("yaml-maybedirective", flag::print);
+    inline const auto Block = TokenDef("yaml-block");
+    inline auto WhitespaceLine = TokenDef("yaml-whitespace-line", flag::print);
+
     inline const auto wf_parse_tokens = Stream | Document | Hyphen | NewLine |
       Whitespace | Value | Int | Float | Hex | True | False | Null | Colon |
       TagDirective | Anchor | Alias | SingleQuote | DoubleQuote |

--- a/parsers/yaml/reader.cc
+++ b/parsers/yaml/reader.cc
@@ -434,7 +434,7 @@ namespace
         result[i] = err(result[i], "Scalar contains '...'");
       }
 
-      if (s.rfind("...") == s.size() - 3)
+      if (s.size() >= 3 && s.rfind("...") == s.size() - 3)
       {
         result[i] = err(result[i], "Scalar contains '...'");
       }
@@ -2558,6 +2558,11 @@ namespace
         T(Indent)
             << (T(WhitespaceLine)++ * T(MappingIndent, SequenceIndent)[Indent] *
                 End) >>
+          [](Match& _) { return _(Indent); },
+
+        T(Indent)
+            << ((T(Line) << (T(Comment) * End))++ *
+                T(MappingIndent, SequenceIndent)[Indent] * End) >>
           [](Match& _) { return _(Indent); },
 
         In(DocumentGroup) * (T(Indent) << (T(Line)[Line] * End)) >>

--- a/parsers/yaml/reader.cc
+++ b/parsers/yaml/reader.cc
@@ -214,7 +214,7 @@ namespace
       return false;
     }
 
-    for (auto& child : *node)
+    for (const Node& child : *node)
     {
       if (!all_empty(child))
       {
@@ -245,7 +245,7 @@ namespace
   {
     std::size_t max_empty_size = 0;
     std::size_t indent = std::string::npos;
-    for (Node n : lines)
+    for (const Node& n : lines)
     {
       auto view = n->location().view();
       std::size_t pos = view.find_first_not_of(" \n");
@@ -443,9 +443,9 @@ namespace
     return result;
   }
 
-  std::string contains_invalid_elements(Nodes lines)
+  std::string contains_invalid_elements(const Nodes& lines)
   {
-    for (Node line : lines)
+    for (const Node& line : lines)
     {
       if (line->location().len == 0)
       {
@@ -534,7 +534,7 @@ namespace
       return false;
     }
 
-    for (auto& child : *node)
+    for (const Node& child : *node)
     {
       if (!all_comments(child))
       {
@@ -599,7 +599,7 @@ namespace
     }
 
     Node flat = NodeDef::create(Group);
-    for (auto& group : *n)
+    for (Node& group : *n)
     {
       flat->insert(flat->end(), group->begin(), group->end());
     }
@@ -628,7 +628,7 @@ namespace
   invalid_tokens(Node n, const std::map<Token, std::string>& token_messages)
   {
     std::size_t changes = 0;
-    for (auto child : *n)
+    for (Node& child : *n)
     {
       if (token_messages.count(child->type()) > 0)
       {
@@ -1064,7 +1064,7 @@ namespace
             Node dirs = _(Directives);
             dirs << _(Head) << _[Tail];
             bool version = false;
-            for (auto dir : *dirs)
+            for (Node& dir : *dirs)
             {
               if (dir->type() == VersionDirective)
               {
@@ -2057,7 +2057,7 @@ namespace
           [](Match& _) {
             if (!_[Tail].empty())
             {
-              for (Node n : _[Tail])
+              for (const Node& n : _[Tail])
               {
                 if (!all_comments(n))
                 {
@@ -2226,7 +2226,7 @@ namespace
               Node value = n.back();
               std::size_t key_indent = min_indent(key);
               std::size_t anchortag_indent = std::string::npos;
-              for (auto child : *value)
+              for (const Node& child : *value)
               {
                 if (child == Anchor || child == Tag)
                 {

--- a/parsers/yaml/reader.cc
+++ b/parsers/yaml/reader.cc
@@ -1881,6 +1881,15 @@ namespace
         In(Line) *
             (T(Comment, "#[^ \t].*: .*")[Comment] * In(MappingIndent)++) >>
           [](Match& _) -> Node {
+          Location loc = _(Comment)->location();
+          auto col = loc.linecol().second;
+          loc.pos -= col;
+          loc.len = col;
+          if (loc.view().find_first_not_of(" \t") == std::string::npos)
+          {
+            return nullptr;
+          }
+
           return err(_(Comment), "Comment that looks like a mapping key");
         },
 
@@ -2148,6 +2157,10 @@ namespace
           [](Match&) -> Node { return nullptr; },
 
         In(SequenceGroup, MappingGroup) * T(WhitespaceLine, EmptyLine) >>
+          [](Match&) -> Node { return nullptr; },
+
+        In(SequenceGroup, MappingGroup) *
+            (T(Indent) << ((T(Line) << (T(Whitespace) * End))++ * End)) >>
           [](Match&) -> Node { return nullptr; },
 
         In(Documents) *

--- a/parsers/yaml/reader.cc
+++ b/parsers/yaml/reader.cc
@@ -12,24 +12,47 @@ namespace
   using namespace trieste;
   using namespace trieste::yaml;
 
+  const auto SequenceItem = TokenDef("yaml-sequenceitem");
+  const auto Indent = TokenDef("yaml-indent");
+  const auto SequenceIndent = TokenDef("yaml-sequenceindent");
+  const auto MappingIndent = TokenDef("yaml-mappingindent");
+  const auto ManualIndent = TokenDef("yaml-manualindent");
+  const auto Line = TokenDef("yaml-line");
+  const auto NonSpecificTag = TokenDef("yaml-nonspecifictag", flag::print);
+  const auto Placeholder = TokenDef("yaml-placeholder");
+  const auto FlowMappingItems = TokenDef("yaml-flowmappingitems");
+  const auto FlowSequenceItems = TokenDef("yaml-flowsequenceitems");
+  const auto FlowSequenceItem = TokenDef("yaml-flowsequenceitem");
+  const auto BlockIndent = TokenDef("yaml-blockindent");
+  const auto BlockStart = TokenDef("yaml-blockstart");
+  const auto ComplexKey = TokenDef("yaml-complexkey");
+  const auto ComplexValue = TokenDef("yaml-complexvalue");
+  const auto FlowKeyValue = TokenDef("yaml-flowkeyvalue", flag::print);
+  const auto Flow = TokenDef("yaml-flow");
+  const auto Extra = TokenDef("yaml-extra");
+  const auto FlowEmpty = TokenDef("yaml-flowempty", flag::print);
+
+  // groups
+  const auto StreamGroup = TokenDef("yaml-streamgroup");
+  const auto DocumentGroup = TokenDef("yaml-documentgroup");
+  const auto TagGroup = TokenDef("yaml-taggroup");
+  const auto FlowGroup = TokenDef("yaml-flowgroup");
+  const auto TagDirectiveGroup = TokenDef("yaml-tagdirectivegroup");
+  const auto SequenceGroup = TokenDef("yaml-sequencegroup");
+  const auto MappingGroup = TokenDef("yaml-mappinggroup");
+  const auto KeyGroup = TokenDef("yaml-keygroup");
+  const auto ValueGroup = TokenDef("yaml-valuegroup");
+  const auto BlockGroup = TokenDef("yaml-blockgroup");
+
+  // utility tokens
+  const auto Lhs = TokenDef("yaml-lhs");
+  const auto Rhs = TokenDef("yaml-rhs");
+  const auto Head = TokenDef("yaml-head");
+  const auto Tail = TokenDef("yaml-tail");
+
   bool is_space(char c)
   {
     return c == ' ' || c == '\t';
-  }
-
-  bool is_in(NodeDef* node, Token parent)
-  {
-    if (node == Top)
-    {
-      return false;
-    }
-
-    if (node == parent)
-    {
-      return true;
-    }
-
-    return is_in(node->parent(), parent);
   }
 
   struct ValuePattern
@@ -147,6 +170,7 @@ namespace
     {
       return std::nullopt;
     }
+
     if (node->type() != Line)
     {
       return measure_indent(node->front());
@@ -221,9 +245,9 @@ namespace
   {
     std::size_t max_empty_size = 0;
     std::size_t indent = std::string::npos;
-    for (auto it = lines.first; it != lines.second; ++it)
+    for (Node n : lines)
     {
-      auto view = (*it)->location().view();
+      auto view = n->location().view();
       std::size_t pos = view.find_first_not_of(" \n");
       if (pos == std::string::npos)
       {
@@ -478,16 +502,16 @@ namespace
 
   std::pair<Node, Node> handle_indent_chomp(NodeRange nodes)
   {
-    if (nodes.first == nodes.second)
+    if (nodes.empty())
     {
       return {nullptr, nullptr};
     }
 
-    Node indent = nodes.first[0];
+    Node indent = nodes.front();
     Node chomp = nullptr;
-    if (std::distance(nodes.first, nodes.second) > 1)
+    if (nodes.size() > 1)
     {
-      chomp = nodes.first[1];
+      chomp = nodes[1];
     }
 
     if (indent != IndentIndicator)
@@ -528,10 +552,8 @@ namespace
       return err(range, "Empty line has too many spaces");
     }
 
-    Nodes lines(range.first, range.second);
-
-    Nodes::iterator end = lines.end();
-    for (auto it = lines.begin(); it != lines.end(); ++it)
+    auto end = range.end();
+    for (auto it = range.begin(); it != range.end(); ++it)
     {
       Node n = *it;
       auto view = n->location().view();
@@ -550,7 +572,7 @@ namespace
       {
         if (view.size() >= indent)
         {
-          end = lines.end();
+          end = range.end();
           continue;
         }
 
@@ -562,10 +584,7 @@ namespace
       }
     }
 
-    if (end != lines.end())
-    {
-      lines.erase(end, lines.end());
-    }
+    Nodes lines(range.begin(), end);
 
     return Seq << (AbsoluteIndent ^ std::to_string(indent)) << chomp_indicator
                << (Lines << lines);
@@ -1006,6 +1025,29 @@ namespace
       wf_values,
       dir::bottomup | dir::once,
       {
+        In(FlowGroup) *
+            (FlowToken[Lhs] * T(Comment)++ * T(Value, R"(:.*)")[Rhs]) >>
+          [patterns](Match& _) {
+            Location loc = _(Rhs)->location();
+            Location colon = loc;
+            colon.len = 1;
+            loc.pos += 1;
+            loc.len -= 1;
+
+            auto view = loc.view();
+            Node value = Value ^ loc;
+            for (auto& pattern : patterns)
+            {
+              if (RE2::FullMatch(view, pattern->regex))
+              {
+                value = (pattern->type ^ loc);
+                break;
+              }
+            }
+
+            return Seq << _(Lhs) << (Colon ^ colon) << value;
+          },
+
         In(DocumentGroup) *
             (Start * ~T(Whitespace) * T(Comment) * T(NewLine)) >>
           [](Match&) -> Node { return nullptr; },
@@ -1061,16 +1103,10 @@ namespace
                        << _(Value);
           },
 
-        In(TagGroup) * T(VerbatimTag)[VerbatimTag]([](auto& n) {
-          auto view = n.first[0]->location().view();
-          return view.find_first_of("{}") != std::string::npos;
-        }) >>
+        In(TagGroup) * T(VerbatimTag, R"(.*[{}].*)")[VerbatimTag] >>
           [](Match& _) { return err(_(VerbatimTag), "Invalid tag"); },
 
-        In(TagGroup) * T(ShorthandTag)[ShorthandTag]([](auto& n) {
-          auto view = n.first[0]->location().view();
-          return view.find_first_of("{}[],") != std::string::npos;
-        }) >>
+        In(TagGroup) * T(ShorthandTag, R"(.*[{}\[\],].*)")[ShorthandTag] >>
           [](Match& _) { return err(_(ShorthandTag), "Invalid tag"); },
 
         In(Stream) * (T(StreamGroup) << (T(Document)++[Documents] * End)) >>
@@ -1090,6 +1126,26 @@ namespace
         In(Tag) * (T(TagGroup) << (T(TagPrefix)[TagPrefix] * End)) >>
           [](Match& _) { return Seq << _[TagPrefix] << (NonSpecificTag ^ ""); },
 
+        T(NewLine, R"(\r?\n(?:\r?\n)+)")[NewLine] >>
+          [](Match& _) {
+            Location loc = _(NewLine)->location();
+            auto view = loc.view();
+            size_t start = 0;
+            size_t end = view.find('\n', start) + 1;
+            Node seq =
+              Seq << (NewLine ^ Location(loc.source, loc.pos + start, end));
+            start = end;
+            while (start < loc.len)
+            {
+              end = view.find('\n', start) + 1;
+              seq
+                << (NewLine ^
+                    Location(loc.source, loc.pos + start, end - start));
+              start = end;
+            }
+            return seq;
+          },
+
         // errors
 
         In(StreamGroup) * (DirectiveToken[Value] * End) >>
@@ -1100,7 +1156,7 @@ namespace
         In(DocumentGroup) *
             (T(MaybeDirective)[MaybeDirective] * ~T(NewLine) *
              End)([](auto& n) {
-              Node dir = n.first[0];
+              Node dir = n.front();
               Node doc = dir->parent()->parent()->shared_from_this();
               Node stream = doc->parent()->shared_from_this();
               return stream->find(doc) < stream->end() - 1;
@@ -1167,27 +1223,9 @@ namespace
           [](Match& _) { return Seq << *_[FlowGroup]; },
 
         In(FlowSequence) *
-            (T(Value)[Value] * T(Comma, FlowSequenceEnd))([](auto& n) {
-              Location loc = n.first[0]->location();
-              return loc.view() == "-";
-            }) >>
+            (T(Value, R"(\-)")[Value] * T(Comma, FlowSequenceEnd)) >>
           [](Match& _) {
             return err(_(Value), "Plain dashes in flow sequence");
-          },
-
-        In(FlowMapping, FlowSequence) *
-            (FlowToken[Lhs] * T(Comment)++ * T(Value)[Rhs])([](auto& n) {
-              Node rhs = *(n.second - 1);
-              Location loc = rhs->location();
-              return loc.view().front() == ':';
-            }) >>
-          [](Match& _) {
-            Location loc = _(Rhs)->location();
-            Location colon = loc;
-            colon.len = 1;
-            loc.pos += 1;
-            loc.len -= 1;
-            return Seq << _(Lhs) << (Colon ^ colon) << (Value ^ loc);
           },
 
         In(FlowMapping, FlowSequence) * (T(Whitespace, NewLine)) >>
@@ -1363,11 +1401,8 @@ namespace
         // errors
         In(DocumentGroup) *
             (T(DocumentStart) * T(Placeholder) * AnchorTag++ * FlowToken *
-             T(Colon)[Colon])([](auto& n) {
-              Node docstart = n.first[0];
-              Node colon = *(n.second - 1);
-              return same_line(docstart, colon);
-            }) >>
+             T(Colon)[Colon])(
+              [](auto& n) { return same_line(n.front(), n.back()); }) >>
           [](Match& _) {
             return err(_(Colon), "Invalid mapping on document start line");
           },
@@ -1375,8 +1410,8 @@ namespace
         In(DocumentGroup) *
             (T(Colon) * T(NewLine) * T(Anchor)[Anchor] * T(NewLine) *
              T(Hyphen))([](auto& n) {
-              auto anchor = n.first[2]->location().linecol().second;
-              auto sequence = n.first[4]->location().linecol().second;
+              auto anchor = n[2]->location().linecol().second;
+              auto sequence = n[4]->location().linecol().second;
               return anchor == 0 && sequence == 0;
             }) >>
           [](Match& _) {
@@ -1488,8 +1523,7 @@ namespace
 
         In(DocumentGroup) *
             (LineToken[Head] * LineToken++[Tail] * End)([](auto& n) {
-              Node head = n.first[0];
-              return head->parent()->parent() == Document;
+              return n.front()->parent()->parent() == Document;
             }) >>
           [](Match& _) { return Line << _(Head) << _[Tail]; },
 
@@ -1659,7 +1693,7 @@ namespace
 
         In(DocumentGroup) *
             ((T(SequenceIndent, MappingIndent)[Indent]
-              << (T(Line) * T(BlockStart))) *
+              << (T(Line) * ~T(Whitespace) * T(BlockStart))) *
              T(WhitespaceLine, EmptyLine)[Line]) >>
           [](Match& _) { return Seq << _(Indent) << (BlockIndent << _(Line)); },
 
@@ -1727,18 +1761,18 @@ namespace
         In(BlockStart) * (~T(Whitespace) * T(Comment)) >>
           [](Match&) -> Node { return nullptr; },
 
-        In(DocumentGroup, Indent, MappingIndent, SequenceIndent) *
+        In(DocumentGroup, Indent, MappingIndent, SequenceIndent, BlockIndent) *
             (IndentToken[Indent] * T(EmptyLine, WhitespaceLine)[Line]) >>
           [](Match& _) { return _(Indent)->type() << *_[Indent] << _(Line); },
 
-        In(DocumentGroup, Indent, MappingIndent, SequenceIndent) *
+        In(DocumentGroup, Indent, MappingIndent, SequenceIndent, BlockIndent) *
             (IndentToken[Lhs] * IndentToken[Rhs])(
-              [](auto& n) { return less_indented(n.first[0], n.first[1]); }) >>
+              [](auto& n) { return less_indented(n.front(), n.back()); }) >>
           [](Match& _) { return _(Lhs)->type() << *_[Lhs] << _(Rhs); },
 
-        In(DocumentGroup, Indent, MappingIndent, SequenceIndent) *
+        In(DocumentGroup, Indent, MappingIndent, SequenceIndent, BlockIndent) *
             (IndentToken[Lhs] * IndentToken[Rhs])(
-              [](auto& n) { return same_indent(n.first[0], n.first[1]); }) >>
+              [](auto& n) { return same_indent(n.front(), n.back()); }) >>
           [](Match& _) {
             if (_(Lhs)->type() == _(Rhs)->type())
             {
@@ -1754,12 +1788,32 @@ namespace
           [](Match& _) { return _(Indent); },
 
         In(SequenceIndent) *
-            ((T(Line)[Line]
-              << (~T(Whitespace) * T(Hyphen) * AnchorTag++ *
-                  (T(Literal, Folded, Value)))) *
+            ((T(Line)[Line] << (~T(Whitespace) * T(Hyphen) * T(Value))) *
              (T(MappingIndent, SequenceIndent))[Indent]) >>
           [](Match& _) {
             return Seq << _(Line) << (BlockIndent << *_[Indent]);
+          },
+
+        In(BlockIndent) * T(Indent, MappingIndent, SequenceIndent)[Indent] >>
+          [](Match& _) { return BlockIndent << *_[Indent]; },
+
+        In(BlockIndent) *
+            (T(Line)[Line] << (T(Whitespace)[Whitespace] * Any[Value] * Any)) >>
+          [](Match& _) {
+            Location start = _(Value)->location();
+            Location end = _(Line)->back()->location();
+            Location loc = start;
+            loc.len = end.pos + end.len - start.pos;
+            return Line << _(Whitespace) << (Value ^ loc);
+          },
+
+        In(SequenceIndent) *
+            ((T(Line)[Line] << (~T(Whitespace) * T(Hyphen))) *
+             T(BlockStart)[BlockStart] *
+             (T(MappingIndent, SequenceIndent, Indent))[Indent]) >>
+          [](Match& _) {
+            return Seq << _(Line) << _(BlockStart)
+                       << (BlockIndent << *_[Indent]);
           },
 
         In(MappingIndent) *
@@ -1811,7 +1865,7 @@ namespace
           },
 
         In(SequenceIndent) * T(Indent, BlockIndent)[Indent]([](auto& n) {
-          Node indent = n.first[0];
+          Node indent = n.front();
           Node parent = indent->parent()->shared_from_this();
           return same_indent(parent, indent);
         }) >>
@@ -1824,16 +1878,8 @@ namespace
           return err(_(Indent), "Wrong indentation");
         },
 
-        In(Line) * T(Comment)[Comment]([](auto& n) {
-          Node comment = n.first[0];
-          if (!is_in(comment->parent(), MappingIndent))
-          {
-            return false;
-          }
-
-          auto view = comment->location().view();
-          return view.find(": ") != std::string::npos;
-        }) >>
+        In(Line) *
+            (T(Comment, "#[^ \t].*: .*")[Comment] * In(MappingIndent)++) >>
           [](Match& _) -> Node {
           return err(_(Comment), "Comment that looks like a mapping key");
         },
@@ -1960,11 +2006,7 @@ namespace
           },
 
         In(MappingGroup) *
-            (T(Line) << (T(Whitespace)[Whitespace]))([](auto& n) {
-              Node ws = n.first[0]->front();
-              auto view = ws->location().view();
-              return view.find('\t') != std::string::npos;
-            }) >>
+            (T(Line) << (T(Whitespace, R"(.*\t.*)")[Whitespace])) >>
           [](Match& _) {
             return err(_(Whitespace), "Tab character in indentation");
           },
@@ -2004,14 +2046,13 @@ namespace
                  ~T(Whitespace) * T(Colon) * AnchorTag++[Rhs] *
                  ValueToken[Head] * Any++[Tail])) >>
           [](Match& _) {
-            NodeRange tail = _[Tail];
-            if (tail.first != tail.second)
+            if (!_[Tail].empty())
             {
-              for (auto it = tail.first; it != tail.second; ++it)
+              for (Node n : _[Tail])
               {
-                if (!all_comments(*it))
+                if (!all_comments(n))
                 {
-                  return err(*it, "Trailing content on mapping item");
+                  return err(n, "Trailing content on mapping item");
                 }
               }
             }
@@ -2132,7 +2173,7 @@ namespace
         In(SequenceItem) *
             (T(ValueGroup) << (T(FlowMapping, FlowSequence))[Flow])(
               [](auto& n) {
-                Node group = n.first[0];
+                Node group = n.front();
                 Node item = group->parent()->shared_from_this();
                 Node flow = group->front();
                 std::size_t item_indent = item->location().linecol().second;
@@ -2145,8 +2186,8 @@ namespace
             (T(KeyGroup) *
              (T(ValueGroup) << (T(FlowMapping, FlowSequence)))[Flow])(
               [](auto& n) {
-                Node key = n.first[0];
-                Node value = n.first[1];
+                Node key = n.front();
+                Node value = n.back();
                 Node flow = value->front();
                 std::size_t item_indent = min_indent(key);
                 std::size_t flow_indent = min_indent(flow);
@@ -2156,7 +2197,7 @@ namespace
 
         In(MappingItem) *
             (T(KeyGroup) << (T(FlowMapping, FlowSequence))[Flow])([](auto& n) {
-              Node key = n.first[0];
+              Node key = n.front();
               Node flow = key->front();
               std::size_t line0 = flow->front()->location().linecol().first;
               std::size_t line1 = flow->back()->location().linecol().first;
@@ -2168,8 +2209,8 @@ namespace
 
         In(MappingItem) *
             (T(KeyGroup) * (T(ValueGroup) << AnchorTag++[Anchor]))([](auto& n) {
-              Node key = n.first[0];
-              Node value = n.first[1];
+              Node key = n.front();
+              Node value = n.back();
               std::size_t key_indent = min_indent(key);
               std::size_t anchortag_indent = std::string::npos;
               for (auto child : *value)
@@ -2248,8 +2289,7 @@ namespace
           },
 
         In(Document) * (T(DocumentGroup)[Group] << T(Indent))([](auto& n) {
-          Node g = n.first[0];
-          return all_comments(g->front());
+          return all_comments(n.front()->front());
         }) >>
           [](Match& _) {
             Node g = _(Group);
@@ -2283,7 +2323,7 @@ namespace
           },
 
         In(MappingIndent, SequenceIndent) * T(Indent)[Indent]([](auto& n) {
-          return all_comments(n.first[0]);
+          return all_comments(n.front());
         }) >>
           [](Match&) -> Node { return nullptr; },
 
@@ -2473,15 +2513,7 @@ namespace
         In(Plain) * T(WhitespaceLine)[WhitespaceLine] >>
           [](Match& _) { return EmptyLine ^ _(WhitespaceLine); },
 
-        In(BlockGroup) * T(BlockLine)[BlockLine]([](auto& n) {
-          Location loc = n.first[0]->location();
-          if (loc.len == 0)
-          {
-            return false;
-          }
-
-          return loc.view().find('\n') != std::string::npos;
-        }) >>
+        In(BlockGroup) * T(BlockLine, R"(.*\n.*)")[BlockLine] >>
           [](Match& _) {
             Nodes lines;
             Location loc = _(BlockLine)->location();
@@ -2507,15 +2539,7 @@ namespace
             return Seq << lines;
           },
 
-        In(Plain) * T(BlockLine)[BlockLine]([](auto& n) {
-          auto loc = n.first[0]->location();
-          if (loc.len == 0)
-          {
-            return false;
-          }
-          char c = loc.view().back();
-          return c == ' ' || c == '\t';
-        }) >>
+        In(Plain) * T(BlockLine, R"(.*[ \t])")[BlockLine] >>
           [](Match& _) {
             Location loc = _(BlockLine)->location();
             auto view = loc.view();
@@ -2567,15 +2591,7 @@ namespace
             return err(_(IndentIndicator), "Invalid indent indicator");
           },
 
-        In(BlockGroup) * T(BlockLine)[BlockLine]([](auto& n) {
-          Location loc = n.first[0]->location();
-          if (loc.len == 0)
-          {
-            return false;
-          }
-
-          return loc.view()[0] == '\t';
-        }) >>
+        In(BlockGroup) * T(BlockLine, "\t.*")[BlockLine] >>
           [](Match& _) {
             return err(_(BlockLine), "Tab being used as indentation");
           },
@@ -2687,12 +2703,8 @@ namespace
           },
 
         In(TagValue) *
-            (T(TagPrefix)[TagPrefix] * T(TagName)[TagName] *
-             T(Null))([](auto& n) {
-              auto pre = n.first[0]->location().view();
-              auto tag = n.first[1]->location().view();
-              return pre == "!!" && tag == "str";
-            }) >>
+            (T(TagPrefix, "!!")[TagPrefix] * T(TagName, "str")[TagName] *
+             T(Null)) >>
           [](Match& _) {
             return Seq << _(TagPrefix) << _(TagName) << (Empty ^ "");
           },
@@ -2830,8 +2842,7 @@ namespace
           [](Match& _) { return _(FlowSequenceItem)->front(); },
 
         In(TagValue) * T(TagPrefix)[TagPrefix]([](auto& n) {
-          Node pre = n.first[0];
-          return pre->lookup().empty();
+          return n.front()->lookup().empty();
         }) >>
           [](Match& _) { return err(_(TagPrefix), "Invalid tag prefix"); },
       }};
@@ -2932,15 +2943,11 @@ namespace
       dir::bottomup,
       {
         In(SingleQuote, DoubleQuote) *
-            (T(BlockLine)[Lhs] * T(BlockLine)[Rhs])([](auto& n) {
-              return n.first[0]->location().len == 0 &&
-                n.first[1]->location().len == 0;
-            }) >>
-          [](Match& _) { return _(Lhs); },
+            (T(BlockLine, "")[Lhs] * T(BlockLine, "")[Rhs]) >>
+          [](Match&) { return BlockLine ^ " "; },
 
         In(SingleQuote, DoubleQuote) *
-            (T(EmptyLine)[Lhs] * T(BlockLine)[Rhs])(
-              [](auto& n) { return n.first[1]->location().len == 0; }) >>
+            (T(EmptyLine)[Lhs] * T(BlockLine, "")[Rhs]) >>
           [](Match& _) { return _(Lhs); },
 
         In(AnchorValue) * T(AnchorValue)[AnchorValue] >>
@@ -2948,17 +2955,7 @@ namespace
             return err(_(AnchorValue), "One value cannot have two anchors");
           },
 
-        In(AnchorValue) * T(Anchor)[Anchor]([](auto& n) {
-          Location loc = n.first[0]->location();
-          if (loc.len == 0)
-          {
-            return false;
-          }
-
-          auto view = loc.view();
-          return view.front() == '&' || view.back() == ' ' ||
-            view.back() == '\t';
-        }) >>
+        In(AnchorValue) * T(Anchor, R"(&.*|.*[ \t])")[Anchor] >>
           [](Match& _) {
             Location loc = _(Anchor)->location();
             auto view = loc.view();
@@ -2969,10 +2966,7 @@ namespace
             return Anchor ^ loc;
           },
 
-        T(Alias)[Alias]([](auto& n) {
-          Node anchor = n.first[0];
-          return anchor->location().view().front() == '*';
-        }) >>
+        T(Alias, R"(\*.*)")[Alias] >>
           [](Match& _) {
             Location loc = _(Alias)->location();
             loc.pos += 1;
@@ -3002,7 +2996,7 @@ namespace
 
         In(Mapping) *
             (T(MappingItem) * T(MappingItem)[MappingItem])(
-              [](auto& n) { return same_line(n.first[0], n.first[1]); }) >>
+              [](auto& n) { return same_line(n.front(), n.back()); }) >>
           [](Match& _) {
             return err(
               _(MappingItem),

--- a/parsers/yaml/writer.cc
+++ b/parsers/yaml/writer.cc
@@ -50,7 +50,7 @@ namespace
     }
   };
 
-  Node unwrap(Node node)
+  Node unwrap(const Node& node)
   {
     if (node->in({TagValue, AnchorValue}))
     {
@@ -60,7 +60,7 @@ namespace
     return node;
   }
 
-  bool is_complex(Node mappingitem)
+  bool is_complex(const Node& mappingitem)
   {
     Node key = unwrap(mappingitem / Key);
     if (key->in(
@@ -71,7 +71,7 @@ namespace
 
     if (key == DoubleQuote)
     {
-      for (auto line : *key)
+      for (const Node& line : *key)
       {
         if (line->location().view().find(':') != std::string::npos)
         {
@@ -83,7 +83,7 @@ namespace
     return false;
   }
 
-  bool is_in(Node node, std::set<Token> tokens)
+  bool is_in(const Node& node, std::set<Token> tokens)
   {
     NodeDef* parent = node->parent();
     while (parent != Top)
@@ -226,7 +226,10 @@ namespace
   }
 
   bool write_value(
-    std::ostream& os, WriteOptions& options, const Spaces& spaces, Node value);
+    std::ostream& os,
+    WriteOptions& options,
+    const Spaces& spaces,
+    const Node& value);
 
   bool write_sequence(
     std::ostream& os,
@@ -242,7 +245,7 @@ namespace
 
     bool not_first = false;
     Spaces new_spaces = spaces.in().indent(2);
-    for (auto item : *sequence)
+    for (const Node& item : *sequence)
     {
       if (not_first)
       {
@@ -273,7 +276,7 @@ namespace
     std::ostream& os,
     WriteOptions& options,
     const Spaces& spaces,
-    Node mappingitem,
+    const Node& mappingitem,
     bool not_first)
   {
     Node key = mappingitem / Key;
@@ -302,7 +305,10 @@ namespace
   }
 
   bool write_mapping(
-    std::ostream& os, WriteOptions& options, const Spaces& spaces, Node mapping)
+    std::ostream& os,
+    WriteOptions& options,
+    const Spaces& spaces,
+    const Node& mapping)
   {
     if (mapping->empty())
     {
@@ -312,7 +318,7 @@ namespace
 
     bool not_first = false;
     Spaces new_spaces = spaces.in().indent(options.indent);
-    for (auto mappingitem : *mapping)
+    for (const Node& mappingitem : *mapping)
     {
       if (is_complex(mappingitem))
       {
@@ -389,7 +395,7 @@ namespace
   }
 
   std::string unescape_block(
-    Node node,
+    const Node& node,
     const std::string& str,
     WriteOptions& options,
     const std::string& indent)
@@ -466,7 +472,10 @@ namespace
   }
 
   void write_block(
-    std::ostream& os, WriteOptions& options, const Spaces& spaces, Node block)
+    std::ostream& os,
+    WriteOptions& options,
+    const Spaces& spaces,
+    const Node& block)
   {
     std::ostringstream ss;
     block_to_string(ss, block);
@@ -551,8 +560,8 @@ namespace
            }) != str.end();
   }
 
-  std::string
-  plain_to_string(Node plain, WriteOptions& options, const Spaces& spaces)
+  std::string plain_to_string(
+    const Node& plain, WriteOptions& options, const Spaces& spaces)
   {
     std::ostringstream os;
     block_to_string(os, plain);
@@ -602,12 +611,20 @@ namespace
   }
 
   bool write_value(
-    std::ostream& os, WriteOptions& options, const Spaces& spaces, Node value)
+    std::ostream& os,
+    WriteOptions& options,
+    const Spaces& spaces,
+    const Node& maybe_value)
   {
-    bool tag_anchor = value->in({TagValue, AnchorValue});
+    bool tag_anchor = maybe_value->in({TagValue, AnchorValue});
+    Node value;
     if (tag_anchor)
     {
-      value = handle_tag_anchor(os, options, spaces, value);
+      value = handle_tag_anchor(os, options, spaces, maybe_value);
+    }
+    else
+    {
+      value = maybe_value;
     }
 
     if (value->in({Mapping, FlowMapping}))
@@ -693,7 +710,8 @@ namespace
     return true;
   }
 
-  bool write_directive(std::ostream& os, WriteOptions& options, Node directive)
+  bool write_directive(
+    std::ostream& os, WriteOptions& options, const Node& directive)
   {
     if (directive == VersionDirective)
     {
@@ -703,12 +721,15 @@ namespace
   }
 
   bool write_document(
-    std::ostream& os, WriteOptions& options, Node document, bool not_first)
+    std::ostream& os,
+    WriteOptions& options,
+    const Node& document,
+    bool not_first)
   {
     Node directives = document / Directives;
     if (!directives->empty() && not_first && options.canonical)
     {
-      for (auto directive : *directives)
+      for (const Node& directive : *directives)
       {
         if (write_directive(os, options, directive))
         {
@@ -765,11 +786,11 @@ namespace
     return false;
   }
 
-  bool write_stream(std::ostream& os, WriteOptions& options, Node stream)
+  bool write_stream(std::ostream& os, WriteOptions& options, const Node& stream)
   {
     Node documents = stream / Documents;
     bool not_first = false;
-    for (auto document : *documents)
+    for (const Node& document : *documents)
     {
       write_document(os, options, document, not_first);
       not_first = true;

--- a/parsers/yaml/writer.cc
+++ b/parsers/yaml/writer.cc
@@ -828,12 +828,10 @@ namespace trieste
         yaml = yaml->front();
       }
 
-      WFContext context;
-      wf::push_back(yaml::wf);
+      WFContext context(yaml::wf);
       std::ostringstream os;
       WriteOptions options = {newline, indent, canonical, false};
       write_stream(os, options, yaml);
-      wf::pop_front();
       return os.str();
     }
   }

--- a/parsers/yaml/writer.cc
+++ b/parsers/yaml/writer.cc
@@ -828,11 +828,13 @@ namespace trieste
         yaml = yaml->front();
       }
 
+      wf::new_context();
       wf::push_back(yaml::wf);
       std::ostringstream os;
       WriteOptions options = {newline, indent, canonical, false};
       write_stream(os, options, yaml);
       wf::pop_front();
+      wf::end_context();
       return os.str();
     }
   }

--- a/parsers/yaml/writer.cc
+++ b/parsers/yaml/writer.cc
@@ -828,13 +828,12 @@ namespace trieste
         yaml = yaml->front();
       }
 
-      wf::new_context();
+      WFContext context;
       wf::push_back(yaml::wf);
       std::ostringstream os;
       WriteOptions options = {newline, indent, canonical, false};
       write_stream(os, options, yaml);
       wf::pop_front();
-      wf::end_context();
       return os.str();
     }
   }

--- a/parsers/yaml/yamlc.cc
+++ b/parsers/yaml/yamlc.cc
@@ -29,6 +29,10 @@ int main(int argc, char** argv)
   app.add_flag(
     "--prettyprint", prettyprint, "Pretty print the output (for JSON)");
 
+  bool sort_keys{false};
+  app.add_flag(
+    "--sort-keys", sort_keys, "Sort object keys in the output (for JSON)");
+
   auto modes = {"event", "json", "yaml"};
   std::string mode;
   app.add_option("-m,--mode", mode, "Output mode.")
@@ -69,7 +73,7 @@ int main(int argc, char** argv)
   trieste::Reader reader = yaml::reader()
                              .file(input_path)
                              .debug_enabled(!debug_path.empty())
-                             .debug_path(debug_path)
+                             .debug_path(debug_path / "inyaml")
                              .wf_check_enabled(wf_checks);
   Destination dest = output_path.empty() ?
     DestinationDef::console() :
@@ -85,7 +89,7 @@ int main(int argc, char** argv)
     result = reader >> yaml::event_writer(output_path)
                          .destination(dest)
                          .debug_enabled(!debug_path.empty())
-                         .debug_path(debug_path)
+                         .debug_path(debug_path / "event")
                          .wf_check_enabled(wf_checks);
     ;
   }
@@ -93,9 +97,9 @@ int main(int argc, char** argv)
   {
     result = reader >> yaml::to_json()
                          .debug_enabled(!debug_path.empty())
-                         .debug_path(debug_path)
+                         .debug_path(debug_path / "json")
                          .wf_check_enabled(wf_checks) >>
-      json::writer(output_path, prettyprint)
+      json::writer(output_path, prettyprint, sort_keys)
         .destination(dest)
         .debug_enabled(!debug_path.empty())
         .debug_path(debug_path)
@@ -107,7 +111,7 @@ int main(int argc, char** argv)
     result = reader >> yaml::writer(output_path.filename().string())
                          .destination(dest)
                          .debug_enabled(!debug_path.empty())
-                         .debug_path(debug_path)
+                         .debug_path(debug_path / "outyaml")
                          .wf_check_enabled(wf_checks);
     ;
   }

--- a/samples/infix/infix.cc
+++ b/samples/infix/infix.cc
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     }
 
     Node calc = result.ast->front();
-    for (auto& output : *calc)
+    for (const Node& output : *calc)
     {
       auto str = output->front()->location().view();
       auto val = output->back()->location().view();

--- a/samples/infix/writers.cc
+++ b/samples/infix/writers.cc
@@ -306,7 +306,7 @@ namespace
 
     if (node == Calculation)
     {
-      for (auto& step : *node)
+      for (const Node& step : *node)
       {
         if (write_infix(os, step))
         {
@@ -397,7 +397,7 @@ namespace
 
     if (node == Calculation)
     {
-      for (auto& step : *node)
+      for (const Node& step : *node)
       {
         if (write_postfix(os, step))
         {

--- a/samples/infix/writers.cc
+++ b/samples/infix/writers.cc
@@ -26,15 +26,12 @@ namespace
 
   bool exists(const NodeRange& n)
   {
-    Node node = *n.first;
-    auto defs = node->lookup();
-    return defs.size() > 0;
+    return !n.front()->lookup().empty();
   }
 
   bool can_replace(const NodeRange& n)
   {
-    Node node = *n.first;
-    auto defs = node->lookup();
+    auto defs = n.front()->lookup();
     if (defs.size() == 0)
     {
       return false;


### PR DESCRIPTION
This commit adds a new `Fuzzer` class, which encapsulates the logic from `Driver` and allows it to be applied to the new `Reader`, `Writer`, and `Rewriter` classes. Another global change is the addition of a stack of wellformedness contexts. By calling `wf::new_context` and `wf::end_context`, it is possible to have nested Trieste pass ranges execute. This allows a Trieste pass to execute another Trieste pass as part of its execution (e.g. to parse a string using the JSON parser and the convert the resulting AST to a language-specific format). Finally, this commit changes `NodeRange` to be a `std::span` (NB an equivalent class is provided for C++17).

### YAML
- Fixed a bug with block indents that contain YAML or JSON
- Fixed a bug where a colon is immediately adjacent to the start of a flow construct
- Fixed a bug with colons immediately adjacent to values inside flow constructs
- Fixed an overeager error message for comments that look like mapping keys
- Fixed a bug with bad aliases in `to_json`

### JSON
- Added `unescape` and `escape` functions for handling JSON strings
- Added a symbol table to `Object` and a `Key` token to make JSON ASTs easier to use

### Misc
- Added some code to mitigate situations in which P(c | d, p) is uniform during fuzzing.
- Added `find_first` and `contains` methods on `Node` which implement `Token` specific logic.
- Added `postparse` and `output_wf` properties for `Reader`
- Added `input_wf`, `output_wf` and `passes` properties for `Rewriter`
- Added `input_wf` and `passes` properties for `Writer`