### PR TITLE
Removing stray semicolons

### DIFF
--- a/parsers/json/reader.cc
+++ b/parsers/json/reader.cc
@@ -215,7 +215,7 @@ namespace
     });
 
     return structure;
-  };
+  }
 }
 
 namespace trieste

--- a/parsers/yaml/internal.h
+++ b/parsers/yaml/internal.h
@@ -58,7 +58,6 @@ namespace trieste
       Folded | IndentIndicator | ChompIndicator | Key | FlowMapping |
       FlowMappingStart | FlowMappingEnd | FlowSequence | FlowSequenceStart |
       FlowSequenceEnd | Comma | Comment | MaybeDirective;
-    ;
 
     // clang-format off
   inline const auto wf_parse =


### PR DESCRIPTION
The Python wheel building system on CentOS objects to these semicolons.