### PR TITLE
Large file validity check.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(TRIESTE_SANITIZE "" CACHE STRING "Argument to pass to sanitize (disabled by 
 FetchContent_Declare(
   snmalloc
   GIT_REPOSITORY https://github.com/microsoft/snmalloc
-  GIT_TAG 2dba088d243e24d4ff09a016ef33a8a06f298980
+  GIT_TAG 835ab5186325736ff5aa8ef53728970d1d74c3bc
   GIT_SHALLOW TRUE
 )
 

--- a/include/trieste/parse.h
+++ b/include/trieste/parse.h
@@ -414,13 +414,19 @@ namespace trieste
           {
             Node node = frontier.back();
             frontier.pop_back();
-            if (node == Invalid)
+
+            if (node == Invalid || node == Error)
             {
               invalid++;
+              continue;
+            }
+
+            if (node->empty())
+            {
+              valid++;
             }
             else
             {
-              valid++;
               for (auto& child : *node)
               {
                 frontier.push_back(child);

--- a/samples/infix/CMakeLists.txt
+++ b/samples/infix/CMakeLists.txt
@@ -9,6 +9,8 @@ target_link_libraries(infix_trieste
 )
  
 add_test(NAME infix COMMAND infix_trieste test -f)
+add_test(NAME invalid_input COMMAND infix ./infix)
+set_property(TEST invalid_input PROPERTY WILL_FAIL On)
 
 add_executable(infix
   reader.cc

--- a/samples/infix/infix.cc
+++ b/samples/infix/infix.cc
@@ -36,40 +36,48 @@ int main(int argc, char** argv)
     output_path = mode;
   }
 
-  ProcessResult result;
-  if (mode == "calculate")
+  try
   {
-    result = reader >> infix::calculate();
+    ProcessResult result;
+    if (mode == "calculate")
+    {
+      result = reader >> infix::calculate();
+      if (!result.ok)
+      {
+        logging::Error err;
+        result.print_errors(err);
+        return 1;
+      }
+
+      Node calc = result.ast->front();
+      for (const Node& output : *calc)
+      {
+        auto str = output->front()->location().view();
+        auto val = output->back()->location().view();
+        std::cout << str << " " << val << std::endl;
+      }
+
+      return 0;
+    }
+    if (mode == "infix")
+    {
+      result = reader >> infix::writer(output_path).destination(dest);
+    }
+    else if (mode == "postfix")
+    {
+      result = reader >> infix::postfix_writer(output_path).destination(dest);
+    }
+
     if (!result.ok)
     {
       logging::Error err;
       result.print_errors(err);
       return 1;
     }
-
-    Node calc = result.ast->front();
-    for (const Node& output : *calc)
-    {
-      auto str = output->front()->location().view();
-      auto val = output->back()->location().view();
-      std::cout << str << " " << val << std::endl;
-    }
-
-    return 0;
   }
-  if (mode == "infix")
+  catch (const std::exception& e)
   {
-    result = reader >> infix::writer(output_path).destination(dest);
-  }
-  else if (mode == "postfix")
-  {
-    result = reader >> infix::postfix_writer(output_path).destination(dest);
-  }
-
-  if (!result.ok)
-  {
-    logging::Error err;
-    result.print_errors(err);
+    std::cerr << e.what() << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
This commit adds a check for large files (> 64kb) to check that they are valid inputs. Previously, Trieste would try to read an input file into main memory as a string, regardless of whether that file actually contains something the parser will consider valid. With this change, Trieste will first try parsing the first 4kb of any file over 64kb to see if the parser largely accepts it, and only then continue parsing the rest of the file.