### PR TITLE
Fix for large JSON files

### DIFF
--- a/parsers/json/parse.cc
+++ b/parsers/json/parse.cc
@@ -91,6 +91,7 @@ namespace trieste
         {
           m.error("Mismatched braces or brackets");
         }
+        stack->clear();
       });
 
       return p;


### PR DESCRIPTION
Very large JSON files will have residual stack values (due to the preview check) which were not clear, meaning that they could not successfully parse.