### PR TITLE
Dealing with large files

### DIFF
--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -29,24 +29,19 @@ namespace trieste
     std::vector<size_t> lines;
 
   public:
-    static Source
-    load_bytes(const std::filesystem::path& file, std::size_t size)
+    static Source load(const std::filesystem::path& file)
     {
       std::ifstream f(file, std::ios::binary | std::ios::in | std::ios::ate);
 
       if (!f)
         return {};
 
-      size_t file_size = static_cast<size_t>(std::filesystem::file_size(file));
-      if (size == 0 || size > file_size)
-      {
-        size = file_size;
-      }
-
+      auto size = f.tellg();
       f.seekg(0, std::ios::beg);
+
       auto source = std::make_shared<SourceDef>();
       source->origin_ = std::filesystem::relative(file).string();
-      source->contents.resize(size);
+      source->contents.resize(static_cast<std::size_t>(size));
       f.read(&source->contents[0], size);
 
       if (!f)
@@ -54,11 +49,6 @@ namespace trieste
 
       source->find_lines();
       return source;
-    }
-
-    static Source load(const std::filesystem::path& file)
-    {
-      return load_bytes(file, 0);
     }
 
     static Source synthetic(const std::string& contents)


### PR DESCRIPTION
My previous attempt at dealing with large files had trouble with large files which contained significant segments of invalid tokens sequestered within a string literal at the beginning of the file (where I performed my preview). This necessitated a different approach. This new solution has the advantage of both being simpler (just based on error counting) and also being robust to this sort of problem.