### PR TITLE
Let Location::str() handle `\r` correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,10 @@ export(EXPORT ${PROJECT_NAME}_Targets
 export(PACKAGE trieste)
 
 # #############################################
+# # Add core Trieste tests
+add_subdirectory(test)
+
+# #############################################
 # # Add samples
 if(TRIESTE_BUILD_SAMPLES)
   enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,12 +175,12 @@ export(PACKAGE trieste)
 
 # #############################################
 # # Add core Trieste tests
+enable_testing()
 add_subdirectory(test)
 
 # #############################################
 # # Add samples
 if(TRIESTE_BUILD_SAMPLES)
-  enable_testing()
   add_subdirectory(samples/infix)
 endif()
 

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -81,8 +81,11 @@ namespace trieste
       // Find the first line that begins _after_ pos, and then backtrack one
       // element if we need to. We can't write this directly because "last
       // element for which condition was false" is not an stdlib primitive.
-      auto it = std::find_if_not(
-        lines.begin(), lines.end(), [&](std::pair<size_t, size_t> elem) {
+      auto it = std::lower_bound(
+        lines.begin(),
+        lines.end(),
+        pos,
+        [&](std::pair<size_t, size_t> elem, size_t pos) {
           return elem.first <= pos;
         });
       // If we're at the beginning already, or we couldn't find a line after
@@ -94,7 +97,7 @@ namespace trieste
         --it;
       }
 
-      size_t line = it - lines.begin();
+      size_t line = std::distance(lines.begin(), it);
       size_t col = pos - it->first;
 
       return {line, col};

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -210,8 +210,9 @@ namespace trieste
             source->view().substr(interim_pos, linepos2 - interim_pos);
         }
 
-        write_indexed_skipping_r(
-          line_view_first, [&](size_t idx) { return idx < col ? ' ' : '~'; });
+        write_indexed_skipping_r(line_view_first, [&ccol = col](size_t idx) {
+          return idx < ccol ? ' ' : '~';
+        });
         ss << std::endl;
         write_chars_skipping_r(line_view_first);
         write_chars_skipping_r(interim_view);
@@ -230,7 +231,7 @@ namespace trieste
         assert(pos >= linepos);
         write_indexed_skipping_r(
           line_view.substr(0, pos - linepos + len),
-          [&](size_t idx) { return idx < col ? ' ' : '~'; });
+          [&ccol = col](size_t idx) { return idx < ccol ? ' ' : '~'; });
         ss << std::endl;
       }
 

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -136,6 +136,9 @@ namespace trieste
       // print exactly the line and not fragments of \r\n.
       auto try_match = [](std::string_view curr, std::string_view part)
         -> std::optional<std::string_view> {
+        // substr will always return a valid result if the index is in range.
+        // Even if part.size() is out of bounds, we will just get a truncated
+        // string_view to compare against.
         if (curr.substr(0, part.size()) == part)
         {
           return curr.substr(part.size());

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -85,8 +85,8 @@ namespace trieste
         lines.begin(),
         lines.end(),
         pos,
-        [&](std::pair<size_t, size_t> elem, size_t pos) {
-          return elem.first <= pos;
+        [](std::pair<size_t, size_t> elem, size_t pos_) {
+          return elem.first <= pos_;
         });
       // If we're at the beginning already, or we couldn't find a line after
       // pos, then our current line should be fine. If lines is constructed

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -26,7 +26,7 @@ namespace trieste
   private:
     std::string origin_;
     std::string contents;
-    std::vector<size_t> lines;
+    std::vector<std::pair<size_t, size_t>> lines;
 
   public:
     static Source load(const std::filesystem::path& file)
@@ -71,46 +71,97 @@ namespace trieste
 
     std::pair<size_t, size_t> linecol(size_t pos) const
     {
-      // Lines and columns are 0-indexed.
-      auto it = std::lower_bound(lines.begin(), lines.end(), pos);
+      // If we have no lines, contents is an empty string.
+      // Realistically this case will only happen for pos == 0.
+      if (lines.empty())
+      {
+        return {0, pos};
+      }
 
-      auto line = it - lines.begin();
-      auto col = pos;
+      // Find the first line that begins _after_ pos, and then backtrack one
+      // element if we need to. We can't write this directly because "last
+      // element for which condition was false" is not an stdlib primitive.
+      auto it = std::find_if_not(
+        lines.begin(), lines.end(), [&](std::pair<size_t, size_t> elem) {
+          return elem.first <= pos;
+        });
+      // If we're at the beginning already, or we couldn't find a line after
+      // pos, then our current line should be fine. If lines is constructed
+      // correctly, it is on either the only line or the last line (and pos is
+      // on that line or beyond all lines).
+      if (it == lines.end() || (it != lines.begin() && it->first > pos))
+      {
+        --it;
+      }
 
-      if (it != lines.begin())
-        col -= *(it - 1) + 1;
+      size_t line = it - lines.begin();
+      size_t col = pos - it->first;
 
       return {line, col};
     }
 
     std::pair<size_t, size_t> linepos(size_t line) const
     {
-      // Lines are 0-indexed.
-      if (line > lines.size())
-        return {std::string::npos, 0};
+      // Special case: for out of range lines, index them at the end of our
+      // string and give them length 0. This will cause minimally-ugly
+      // misbehavior if there's an out of range error. Also, this gracefully
+      // handles the technically out of range situation where we ask for line 0
+      // of an empty string, which is what linecol(0) will give its caller in
+      // that case.
 
-      size_t start = 0;
-      auto end = contents.size();
+      // Change note: this used to return std::string::npos when line was out of
+      // range by more than 1, but callers weren't checking for it so that case
+      // just caused things like .subtr(max_long) in practice. Best return an
+      // empty line with max idx, which will cause blank outputs. Otherwise,
+      // actually assert(line <= lines.size()) to crash here and not half way
+      // down the calling function.
+      if (line >= lines.size())
+      {
+        return {contents.size(), 0};
+      }
 
-      if (line > 0)
-        start = lines[line - 1] + 1;
-
-      if (line < lines.size())
-        end = lines[line];
-
-      return {start, end - start};
+      return lines[line]; // already in {start, size} format
     }
 
   private:
     void find_lines()
     {
-      // Find the lines.
-      auto pos = contents.find('\n');
+      using namespace std::string_view_literals;
+      // Find the lines (accounting for cross-platform line ending issues).
+      // We store the size of the line to support linepos(line), so people can
+      // print exactly the line and not fragments of \r\n.
+      size_t cursor = 0;
+      auto try_match = [&](std::string_view part) -> bool {
+        if (std::string_view(contents).substr(cursor, part.size()) == part)
+        {
+          cursor += part.size();
+          return true;
+        }
+        else
+        {
+          return false;
+        }
+      };
 
-      while (pos != std::string::npos)
+      size_t line_start = 0;
+      while (cursor < contents.size())
       {
-        lines.push_back(pos);
-        pos = contents.find('\n', pos + 1);
+        size_t last_pos = cursor;
+        if (try_match("\r\n"sv) || try_match("\n"sv) || try_match("\r"sv))
+        {
+          lines.emplace_back(line_start, last_pos - line_start);
+          line_start = cursor;
+        }
+        else
+        {
+          ++cursor;
+        }
+      }
+
+      // Trailing content without a new line at the end
+      if (line_start < contents.size())
+      {
+        lines.emplace_back(line_start, contents.size() - line_start);
       }
     }
   };

--- a/parsers/yaml/event_writer.cc
+++ b/parsers/yaml/event_writer.cc
@@ -423,7 +423,10 @@ namespace trieste
           auto current = node->at(i)->location().view();
           auto next = node->at(i + 1)->location().view();
           os << escape_chars(current, escape);
-          if (!std::isspace(current.front()) && !std::isspace(next.front()))
+          // an empty string view does not start with a space
+          if (
+            (current.empty() || !std::isspace(current.front())) &&
+            (next.empty() || !std::isspace(next.front())))
           {
             os << " ";
           }

--- a/parsers/yaml/to_json.cc
+++ b/parsers/yaml/to_json.cc
@@ -212,7 +212,7 @@ namespace
           [](Match& _) {
             Location loc = _(Key)->location();
             auto view = loc.view();
-            if (view.front() == '"' && view.back() == '"')
+            if (!view.empty() && view.front() == '"' && view.back() == '"')
             {
               loc.pos += 1;
               loc.len -= 2;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,4 +4,4 @@ add_executable(trieste_source_test
 )
 target_link_libraries(trieste_source_test trieste::trieste)
 
-add_test(trieste_source_test COMMAND trieste_source_test --depth 6)
+add_test(NAME trieste_source_test COMMAND trieste_source_test --depth 6)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,4 +4,4 @@ add_executable(trieste_source_test
 )
 target_link_libraries(trieste_source_test trieste::trieste)
 
-add_test(trieste_source_test COMMAND trieste_source_test --depth 4)
+add_test(trieste_source_test COMMAND trieste_source_test --depth 6)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+add_executable(trieste_source_test
+  source_test.cc
+)
+target_link_libraries(trieste_source_test trieste::trieste)
+
+add_test(trieste_source_test COMMAND trieste_source_test --depth 4)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,11 +11,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT TRIESTE_SANITIZE)
   target_link_libraries(trieste_intrusive_ptr_test -fsanitize=thread)
 endif()
 
-add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test)
+add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_intrusive_ptr_test>)
 
 add_executable(trieste_source_test
   source_test.cc
 )
 target_link_libraries(trieste_source_test trieste::trieste)
 
-add_test(NAME trieste_source_test COMMAND trieste_source_test --depth 6)
+add_test(NAME trieste_source_test COMMAND trieste_source_test --depth 6 WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_source_test>)

--- a/test/source_test.cc
+++ b/test/source_test.cc
@@ -37,7 +37,9 @@ namespace
     std::pair<size_t, size_t> expected_linecol;
   };
 
-  std::ostream& operator<<(std::ostream& out, const ExpectedLineCol& expected_linecol) {
+  std::ostream&
+  operator<<(std::ostream& out, const ExpectedLineCol& expected_linecol)
+  {
     out << "pos = " << expected_linecol.pos << std::endl
         << "line = " << expected_linecol.expected_linecol.first << std::endl
         << "col = " << expected_linecol.expected_linecol.second << std::endl;
@@ -50,28 +52,36 @@ namespace
     std::pair<size_t, size_t> expected_linepos;
   };
 
-  std::ostream& operator<<(std::ostream& out, const ExpectedLinePos& expected_linepos) {
+  std::ostream&
+  operator<<(std::ostream& out, const ExpectedLinePos& expected_linepos)
+  {
     out << "line = " << expected_linepos.line << std::endl
         << "pos = " << expected_linepos.expected_linepos.first << std::endl
         << "len = " << expected_linepos.expected_linepos.second << std::endl;
     return out;
   }
 
-  struct ExpectedLocationStr {
+  struct ExpectedLocationStr
+  {
     size_t pos, len;
     bool has_newline;
     size_t last_line_idx;
     std::string expected_begin, expected_middle, expected_end;
   };
 
-  std::ostream& operator<<(std::ostream& out, const ExpectedLocationStr& expected_location) {
+  std::ostream&
+  operator<<(std::ostream& out, const ExpectedLocationStr& expected_location)
+  {
     out << "pos = " << expected_location.pos << std::endl
         << "len = " << expected_location.len << std::endl
         << "has_newline = " << expected_location.has_newline << std::endl
         << "last_line_idx = " << expected_location.last_line_idx << std::endl
-        << "expected_begin = \"" << escape_string(expected_location.expected_begin) << "\"" << std::endl
-        << "expected_middle = \"" << escape_string(expected_location.expected_middle) << "\"" << std::endl
-        << "expected_end = \"" << escape_string(expected_location.expected_end) << "\"" << std::endl;
+        << "expected_begin = \""
+        << escape_string(expected_location.expected_begin) << "\"" << std::endl
+        << "expected_middle = \""
+        << escape_string(expected_location.expected_middle) << "\"" << std::endl
+        << "expected_end = \"" << escape_string(expected_location.expected_end)
+        << "\"" << std::endl;
     return out;
   }
 
@@ -82,7 +92,6 @@ namespace
     size_t curr_line_idx;
     size_t next_line_idx;
     std::string last_visible_line;
-    bool seeking_next_line;
 
     std::vector<ExpectedLinePos> expected_linepos;
     std::vector<ExpectedLineCol> expected_linecol;
@@ -130,20 +139,28 @@ namespace
         }
       }
 
-      for(const auto& check : expected_location_str) {
+      for (const auto& check : expected_location_str)
+      {
         std::string expected_str = ""s;
-        if(check.has_newline) {
+        if (check.has_newline)
+        {
           expected_str = check.expected_begin;
           expected_str += '\n';
         }
-        expected_str += check.expected_middle + "\n" + check.expected_end + "\n";
+        expected_str +=
+          check.expected_middle + "\n" + check.expected_end + "\n";
 
         auto actual = trieste::Location(source, check.pos, check.len).str();
 
-        if(actual != expected_str) {
-          std::cout << "Error finding Location(source, pos = " << check.pos << ", len = " << check.len << ").str() in string \"" << escape_string(input) << "\"." << std::endl
-                    << "expected = \"" << escape_string(expected_str) << "\"" << std::endl
-                    << "actual = \"" << escape_string(actual) << "\"" << std::endl;
+        if (actual != expected_str)
+        {
+          std::cout << "Error finding Location(source, pos = " << check.pos
+                    << ", len = " << check.len << ").str() in string \""
+                    << escape_string(input) << "\"." << std::endl
+                    << "expected = \"" << escape_string(expected_str) << "\""
+                    << std::endl
+                    << "actual = \"" << escape_string(actual) << "\""
+                    << std::endl;
           return false;
         }
       }
@@ -151,64 +168,64 @@ namespace
       return true;
     }
 
-    void dump() const {
+    void dump() const
+    {
       std::cout << "input = \"" << escape_string(input) << "\"" << std::endl
                 << "curr_line_idx = " << curr_line_idx << std::endl
                 << "next_line_idx = " << next_line_idx << std::endl
-                << "last_visible_line = \"" << escape_string(last_visible_line) << "\"" << std::endl
-                << "seeking_next_line = " << seeking_next_line << std::endl;
+                << "last_visible_line = \"" << escape_string(last_visible_line)
+                << "\"" << std::endl;
 
       std::cout << std::endl;
       std::cout << "Expected linecol list:" << std::endl;
-      for(const auto& linecol : expected_linecol) {
-        std::cout << "---" << std::endl
-                  << linecol;
+      for (const auto& linecol : expected_linecol)
+      {
+        std::cout << "---" << std::endl << linecol;
       }
 
       std::cout << std::endl;
       std::cout << "Expected linepos list:" << std::endl;
-      for(const auto& linepos : expected_linepos) {
-        std::cout << "---" << std::endl
-                  << linepos;
+      for (const auto& linepos : expected_linepos)
+      {
+        std::cout << "---" << std::endl << linepos;
       }
 
       std::cout << std::endl;
       std::cout << "Expected location str list:" << std::endl;
-      for(const auto& location_str : expected_location_str) {
-        std::cout << "---" << std::endl
-                  << location_str;
+      for (const auto& location_str : expected_location_str)
+      {
+        std::cout << "---" << std::endl << location_str;
       }
     }
   };
 
-  std::vector<LinesTest> build_cases_size_n(size_t n, bool skip_carriage_returns)
+  std::vector<LinesTest>
+  build_cases_size_n(size_t n, bool skip_carriage_returns)
   {
     if (n == 0)
     {
-      return {{
-        ""s,
-        0,
-        1,
-        ""s,
-        false,
-        {
-          {0, {0, 0}},
-        },
-        {
-          {0, {0, 0}},
-        },
-        {
-          {
-            0,
-            0,
-            false,
-            0,
-            ""s,
-            ""s,
-            ""s,
-          },
-        }
-      }};
+      return {
+        {""s,
+         0,
+         1,
+         ""s,
+         {
+           {0, {0, 0}},
+         },
+         {
+           {0, {0, 0}},
+         },
+         {
+           {
+             0,
+             0,
+             false,
+             0,
+             ""s,
+             ""s,
+             ""s,
+           },
+         }}};
     }
 
     auto cases_pre = build_cases_size_n(n - 1, skip_carriage_returns);
@@ -222,47 +239,65 @@ namespace
       auto gen_strs = [](LinesTest& cs) -> void {
         size_t next_idx = 0;
         auto existing_strs = cs.expected_location_str;
-        // extend all the location str combos that ended at the boundary of the old input
-        for(const auto& existing_location_str : existing_strs) {
-          // we modify the existing elements when the line view (but not span) overlaps the extended input
+        // extend all the location str combos that ended at the boundary of the
+        // old input
+        for (const auto& existing_location_str : existing_strs)
+        {
+          // we modify the existing elements when the line view (but not span)
+          // overlaps the extended input
           size_t curr_idx = next_idx;
           ++next_idx;
 
           // ... right here:
-          // Locations whose line view (but not span) overlaps the extended part of input must gain a char in their line view.
+          // Locations whose line view (but not span) overlaps the extended part
+          // of input must gain a char in their line view.
           {
             auto& location_str = cs.expected_location_str.at(curr_idx);
             // ... but only if our char is not a control char or newline
-            if(cs.input.back() != '\n' && cs.input.back() != '\r') {
-              if(location_str.last_line_idx == cs.curr_line_idx) {
+            if (cs.input.back() != '\n' && cs.input.back() != '\r')
+            {
+              if (location_str.last_line_idx == cs.curr_line_idx)
+              {
                 location_str.expected_middle += cs.input.back();
               }
             }
           }
 
-          if(existing_location_str.pos + existing_location_str.len + 1 != cs.input.size()) {
+          if (
+            existing_location_str.pos + existing_location_str.len + 1 !=
+            cs.input.size())
+          {
             // skip locations that don't end at the end of the string
             continue;
           }
           auto location_str = existing_location_str;
           location_str.len += 1;
 
-          if(cs.input.back() == '\n') {
-            if(!location_str.has_newline) {
-              location_str.expected_begin = std::move(location_str.expected_end);
+          if (cs.input.back() == '\n')
+          {
+            if (!location_str.has_newline)
+            {
+              location_str.expected_begin =
+                std::move(location_str.expected_end);
             }
             location_str.expected_middle += '\n';
             location_str.expected_end = ""s;
             location_str.has_newline = true;
             location_str.last_line_idx += 1;
-          } else if(cs.input.back() == '\r') {
+          }
+          else if (cs.input.back() == '\r')
+          {
             // pass
-          } else if(cs.input.back() == 'a') {
+          }
+          else if (cs.input.back() == 'a')
+          {
             // It doesn't matter if there's a newline or not.
             // Adding a char at the end always grows the '~' at the bottom.
             location_str.expected_middle += 'a';
             location_str.expected_end += '~';
-          } else {
+          }
+          else
+          {
             std::abort();
           }
 
@@ -271,7 +306,7 @@ namespace
 
         // The one extra case: when we point exactly to the end of the input.
         {
-          ExpectedLocationStr location_str {
+          ExpectedLocationStr location_str{
             cs.input.size(),
             0,
             false,
@@ -280,17 +315,13 @@ namespace
             cs.last_visible_line,
             ""s,
           };
-          for(size_t i = 0; i < cs.last_visible_line.size(); ++i) {
+          for (size_t i = 0; i < cs.last_visible_line.size(); ++i)
+          {
             location_str.expected_end += ' ';
           }
           cs.expected_location_str.emplace_back(std::move(location_str));
         }
       };
-
-      if(case_pre.seeking_next_line) {
-        case_pre.seeking_next_line = false;
-        case_pre.last_visible_line = ""s;
-      }
 
       // The newline character
       {
@@ -302,6 +333,7 @@ namespace
         });
         cs.curr_line_idx += 1;
         cs.next_line_idx += 1;
+        cs.last_visible_line = ""s;
         // the linebreak itself is considered to be on the next line
         cs.expected_linecol.push_back({
           old_size + 1,
@@ -310,7 +342,6 @@ namespace
             0,
           },
         });
-        cs.seeking_next_line = true;
         // generate all the extra location str prints
         gen_strs(cs);
 
@@ -319,8 +350,10 @@ namespace
       // not a new line:
       // - character 'a', no need to be imaginative
       // - character '\r', same effect except for visibility in err strings
-      for(char ch : {'a', '\r'}){
-        if(skip_carriage_returns && ch == '\r') {
+      for (char ch : {'a', '\r'})
+      {
+        if (skip_carriage_returns && ch == '\r')
+        {
           continue;
         }
 
@@ -338,7 +371,8 @@ namespace
           },
         });
         // the carriage return should not be considered "visible"
-        if(ch != '\r') {
+        if (ch != '\r')
+        {
           cs.last_visible_line += ch;
         }
         // generate all the extra location str prints
@@ -346,8 +380,6 @@ namespace
 
         cases.emplace_back(std::move(cs));
       }
-
-
     }
     return cases;
   }
@@ -360,8 +392,12 @@ int main(int argc, char** argv)
   bool verbose = false;
   bool skip_carriage_returns = false;
   app.add_option("--depth", depth, "Maximum test string length");
-  app.add_flag("--verbose", verbose, "Print the test cases that were generated.");
-  app.add_flag("--skip-carriage-returns", skip_carriage_returns, "Disable constructing inputs with '\r' in them.");
+  app.add_flag(
+    "--verbose", verbose, "Print the test cases that were generated.");
+  app.add_flag(
+    "--skip-carriage-returns",
+    skip_carriage_returns,
+    "Disable constructing inputs with '\r' in them.");
 
   try
   {
@@ -373,17 +409,32 @@ int main(int argc, char** argv)
   }
 
   std::vector<LinesTest> cases;
-  for(size_t i = 0; i <= depth; ++i) {
-    for(auto&& cs : build_cases_size_n(i, skip_carriage_returns)) {
+  for (size_t i = 0; i <= depth; ++i)
+  {
+    for (auto&& cs : build_cases_size_n(i, skip_carriage_returns))
+    {
       cases.emplace_back(std::move(cs));
     }
-  } 
+  }
+  {
+    size_t case_count = 0;
+    for (const auto& cs : cases)
+    {
+      case_count += cs.expected_linecol.size();
+      case_count += cs.expected_linepos.size();
+      case_count += cs.expected_location_str.size();
+    }
 
-  std::cout << "Generated " << cases.size() << " test cases up to depth " << depth << "." << std::endl;
+    std::cout << "Generated " << cases.size() << " inputs, or " << case_count
+              << " distinct test cases, up to depth " << depth << "."
+              << std::endl;
+  }
 
-  if(verbose) {
+  if (verbose)
+  {
     size_t idx = 0;
-    for(const auto& cs : cases) {
+    for (const auto& cs : cases)
+    {
       std::cout << std::endl;
       std::cout << "# Case " << idx << ":" << std::endl;
       cs.dump();

--- a/test/source_test.cc
+++ b/test/source_test.cc
@@ -1,0 +1,231 @@
+#include "CLI/App.hpp"
+#include "CLI/Error.hpp"
+
+#include <CLI/CLI.hpp>
+#include <trieste/trieste.h>
+
+namespace
+{
+  using namespace std::string_view_literals;
+
+  struct ExpectedLineCol
+  {
+    size_t pos;
+    std::pair<size_t, size_t> expected_linecol;
+  };
+
+  struct ExpectedLinePos
+  {
+    size_t line;
+    std::pair<size_t, size_t> expected_linepos;
+  };
+
+  std::string escape_string(const std::string str)
+  {
+    std::string result;
+    for (auto ch : str)
+    {
+      // This is far from all special chars, but it works for what we emit.
+      switch (ch)
+      {
+        case '\n':
+          result += "\\n"sv;
+          break;
+        case '\r':
+          result += "\\r"sv;
+          break;
+        default:
+          result += ch;
+      }
+    }
+
+    return result;
+  }
+
+  struct LinesTest
+  {
+    std::string input;
+
+    size_t line_idx_after;
+    bool was_line_break;
+    std::vector<ExpectedLinePos> expected_linepos;
+    std::vector<ExpectedLineCol> expected_linecol;
+
+    bool check_all() const
+    {
+      auto source = trieste::SourceDef::synthetic(input);
+
+      for (const auto& check : expected_linepos)
+      {
+        auto actual = source->linepos(check.line);
+
+        if (actual != check.expected_linepos)
+        {
+          const auto& expected = check.expected_linepos;
+          std::cout << "Error finding linepos(line = " << check.line
+                    << ") in string \"" << escape_string(input) << "\"."
+                    << std::endl
+                    << "           (start, size)" << std::endl
+                    << "expected = (" << expected.first << ", "
+                    << expected.second << ")" << std::endl
+                    << "actual   = (" << actual.first << ", " << actual.second
+                    << ")" << std::endl;
+          return false;
+        }
+      }
+
+      for (const auto& check : expected_linecol)
+      {
+        auto actual = source->linecol(check.pos);
+
+        if (actual != check.expected_linecol)
+        {
+          const auto& expected = check.expected_linecol;
+          std::cout << "Error finding linecol(pos = " << check.pos
+                    << ") in string \"" << escape_string(input) << "\"."
+                    << std::endl
+                    << "           (line, col)" << std::endl
+                    << "expected = (" << expected.first << ", "
+                    << expected.second << ")" << std::endl
+                    << "actual   = (" << actual.first << ", " << actual.second
+                    << ")" << std::endl;
+          return false;
+        }
+      }
+
+      return true;
+    }
+  };
+
+  std::vector<LinesTest> build_cases_size_n(size_t n)
+  {
+    if (n == 0)
+    {
+      return {{
+        "",
+        0,
+        false,
+        {
+          {0, {0, 0}},
+        },
+        {
+          {0, {0, 0}},
+        },
+      }};
+    }
+
+    auto cases_pre = build_cases_size_n(n - 1);
+    std::vector<LinesTest> cases;
+    for (auto case_pre : cases_pre)
+    {
+      size_t old_size = case_pre.input.size();
+      assert(!case_pre.expected_linecol.empty());
+      assert(!case_pre.expected_linepos.empty());
+
+      // Cases where case_pre needs "fixing" for a longer input.
+      // Being at the end of the input matters and changes what output makes
+      // sense.
+      if (case_pre.was_line_break)
+      {
+        case_pre.was_line_break = false;
+        // If we're adding a new char of any sort after a line break, we now
+        // have an extra line, starting at size 0. But we didn't before, because
+        // then we just had a trailing line break.
+        case_pre.expected_linepos.push_back({
+          case_pre.line_idx_after,
+          {
+            case_pre.input.size(),
+            0,
+          },
+        });
+        // Also, our linecol(pos = size) case shifts to the beginning of the
+        // next line, now that there is one, as opposed to us us trailing off
+        // the end of the last line.
+        case_pre.expected_linecol.back().expected_linecol = {
+          case_pre.line_idx_after, 0};
+      }
+
+      // cover all line break variations
+      for (auto nl : {"\r\n"sv, "\n"sv, "\r"sv})
+      {
+        if (!case_pre.input.empty())
+        {
+          if (nl == "\n"sv && case_pre.input.back() == '\r')
+          {
+            continue; // this is just "\r\n", and that makes one line break not
+                      // 2
+          }
+        }
+
+        auto cs = case_pre;
+        cs.input += nl;
+        // a) chars after this line break get line number + 1
+        cs.line_idx_after += 1;
+        // b) chars inside the line break stay on the last line, but on extra
+        // columns
+        for (size_t inc = 1; inc <= nl.size(); ++inc)
+        {
+          cs.expected_linecol.push_back({
+            old_size + inc,
+            {
+              case_pre.line_idx_after,
+              case_pre.expected_linecol.back().expected_linecol.second + inc,
+            },
+          });
+        }
+        // c) we don't get a valid next line info if we're a trailing line
+        // break, but the next char will change that
+        cs.was_line_break = true;
+        cases.emplace_back(std::move(cs));
+      }
+      // not a new line (no need to be imaginative here)
+      {
+        auto cs = case_pre;
+        cs.input += "a"sv;
+        // a) no change in line_idx_after, following chars still on same line
+        // b) queries for info on the last line get a longer span by 1
+        cs.expected_linepos.back().expected_linepos.second += 1;
+        // c) queries for this pos get same line as previous pos, +1 column
+        cs.expected_linecol.push_back({
+          cs.input.size(),
+          {
+            case_pre.line_idx_after,
+            case_pre.expected_linecol.back().expected_linecol.second + 1,
+          },
+        });
+        cases.emplace_back(std::move(cs));
+      }
+    }
+    return cases;
+  }
+}
+
+int main(int argc, char** argv)
+{
+  auto app = CLI::App("Tester for Trieste's source location code");
+  size_t depth = 0;
+  app.add_option("--depth", depth, "Maximum test string length");
+
+  try
+  {
+    app.parse(argc, argv);
+  }
+  catch (CLI::ParseError& err)
+  {
+    app.exit(err);
+  }
+
+  auto cases = build_cases_size_n(depth);
+
+  for (const auto& cs : cases)
+  {
+    if (!cs.check_all())
+    {
+      std::cout << "Test failed, aborting." << std::endl;
+      return 1;
+    }
+  }
+
+  std::cout << "All " << cases.size() << " cases passed." << std::endl;
+  return 0;
+}

--- a/test/source_test.cc
+++ b/test/source_test.cc
@@ -139,24 +139,15 @@ namespace
           },
         });
         // Also, our linecol(pos = size) case shifts to the beginning of the
-        // next line, now that there is one, as opposed to us us trailing off
+        // next line, now that there is one, as opposed to us trailing off
         // the end of the last line.
         case_pre.expected_linecol.back().expected_linecol = {
           case_pre.line_idx_after, 0};
       }
 
       // cover all line break variations
-      for (auto nl : {"\r\n"sv, "\n"sv, "\r"sv})
+      for (auto nl : {"\r\n"sv, "\n"sv})
       {
-        if (!case_pre.input.empty())
-        {
-          if (nl == "\n"sv && case_pre.input.back() == '\r')
-          {
-            continue; // this is just "\r\n", and that makes one line break not
-                      // 2
-          }
-        }
-
         auto cs = case_pre;
         cs.input += nl;
         // a) chars after this line break get line number + 1

--- a/test/source_test.cc
+++ b/test/source_test.cc
@@ -7,18 +7,7 @@
 namespace
 {
   using namespace std::string_view_literals;
-
-  struct ExpectedLineCol
-  {
-    size_t pos;
-    std::pair<size_t, size_t> expected_linecol;
-  };
-
-  struct ExpectedLinePos
-  {
-    size_t line;
-    std::pair<size_t, size_t> expected_linepos;
-  };
+  using namespace std::string_literals;
 
   std::string escape_string(const std::string str)
   {
@@ -42,14 +31,62 @@ namespace
     return result;
   }
 
+  struct ExpectedLineCol
+  {
+    size_t pos;
+    std::pair<size_t, size_t> expected_linecol;
+  };
+
+  std::ostream& operator<<(std::ostream& out, const ExpectedLineCol& expected_linecol) {
+    out << "pos = " << expected_linecol.pos << std::endl
+        << "line = " << expected_linecol.expected_linecol.first << std::endl
+        << "col = " << expected_linecol.expected_linecol.second << std::endl;
+    return out;
+  }
+
+  struct ExpectedLinePos
+  {
+    size_t line;
+    std::pair<size_t, size_t> expected_linepos;
+  };
+
+  std::ostream& operator<<(std::ostream& out, const ExpectedLinePos& expected_linepos) {
+    out << "line = " << expected_linepos.line << std::endl
+        << "pos = " << expected_linepos.expected_linepos.first << std::endl
+        << "len = " << expected_linepos.expected_linepos.second << std::endl;
+    return out;
+  }
+
+  struct ExpectedLocationStr {
+    size_t pos, len;
+    bool has_newline;
+    size_t last_line_idx;
+    std::string expected_begin, expected_middle, expected_end;
+  };
+
+  std::ostream& operator<<(std::ostream& out, const ExpectedLocationStr& expected_location) {
+    out << "pos = " << expected_location.pos << std::endl
+        << "len = " << expected_location.len << std::endl
+        << "has_newline = " << expected_location.has_newline << std::endl
+        << "last_line_idx = " << expected_location.last_line_idx << std::endl
+        << "expected_begin = \"" << escape_string(expected_location.expected_begin) << "\"" << std::endl
+        << "expected_middle = \"" << escape_string(expected_location.expected_middle) << "\"" << std::endl
+        << "expected_end = \"" << escape_string(expected_location.expected_end) << "\"" << std::endl;
+    return out;
+  }
+
   struct LinesTest
   {
     std::string input;
 
-    size_t line_idx_after;
-    bool was_line_break;
+    size_t curr_line_idx;
+    size_t next_line_idx;
+    std::string last_visible_line;
+    bool seeking_next_line;
+
     std::vector<ExpectedLinePos> expected_linepos;
     std::vector<ExpectedLineCol> expected_linecol;
+    std::vector<ExpectedLocationStr> expected_location_str;
 
     bool check_all() const
     {
@@ -93,17 +130,66 @@ namespace
         }
       }
 
+      for(const auto& check : expected_location_str) {
+        std::string expected_str = ""s;
+        if(check.has_newline) {
+          expected_str = check.expected_begin;
+          expected_str += '\n';
+        }
+        expected_str += check.expected_middle + "\n" + check.expected_end + "\n";
+
+        auto actual = trieste::Location(source, check.pos, check.len).str();
+
+        if(actual != expected_str) {
+          std::cout << "Error finding Location(source, pos = " << check.pos << ", len = " << check.len << ").str() in string \"" << escape_string(input) << "\"." << std::endl
+                    << "expected = \"" << escape_string(expected_str) << "\"" << std::endl
+                    << "actual = \"" << escape_string(actual) << "\"" << std::endl;
+          return false;
+        }
+      }
+
       return true;
+    }
+
+    void dump() const {
+      std::cout << "input = \"" << escape_string(input) << "\"" << std::endl
+                << "curr_line_idx = " << curr_line_idx << std::endl
+                << "next_line_idx = " << next_line_idx << std::endl
+                << "last_visible_line = \"" << escape_string(last_visible_line) << "\"" << std::endl
+                << "seeking_next_line = " << seeking_next_line << std::endl;
+
+      std::cout << std::endl;
+      std::cout << "Expected linecol list:" << std::endl;
+      for(const auto& linecol : expected_linecol) {
+        std::cout << "---" << std::endl
+                  << linecol;
+      }
+
+      std::cout << std::endl;
+      std::cout << "Expected linepos list:" << std::endl;
+      for(const auto& linepos : expected_linepos) {
+        std::cout << "---" << std::endl
+                  << linepos;
+      }
+
+      std::cout << std::endl;
+      std::cout << "Expected location str list:" << std::endl;
+      for(const auto& location_str : expected_location_str) {
+        std::cout << "---" << std::endl
+                  << location_str;
+      }
     }
   };
 
-  std::vector<LinesTest> build_cases_size_n(size_t n)
+  std::vector<LinesTest> build_cases_size_n(size_t n, bool skip_carriage_returns)
   {
     if (n == 0)
     {
       return {{
-        "",
+        ""s,
         0,
+        1,
+        ""s,
         false,
         {
           {0, {0, 0}},
@@ -111,10 +197,21 @@ namespace
         {
           {0, {0, 0}},
         },
+        {
+          {
+            0,
+            0,
+            false,
+            0,
+            ""s,
+            ""s,
+            ""s,
+          },
+        }
       }};
     }
 
-    auto cases_pre = build_cases_size_n(n - 1);
+    auto cases_pre = build_cases_size_n(n - 1, skip_carriage_returns);
     std::vector<LinesTest> cases;
     for (auto case_pre : cases_pre)
     {
@@ -122,57 +219,113 @@ namespace
       assert(!case_pre.expected_linecol.empty());
       assert(!case_pre.expected_linepos.empty());
 
-      // Cases where case_pre needs "fixing" for a longer input.
-      // Being at the end of the input matters and changes what output makes
-      // sense.
-      if (case_pre.was_line_break)
-      {
-        case_pre.was_line_break = false;
-        // If we're adding a new char of any sort after a line break, we now
-        // have an extra line, starting at size 0. But we didn't before, because
-        // then we just had a trailing line break.
-        case_pre.expected_linepos.push_back({
-          case_pre.line_idx_after,
+      auto gen_strs = [](LinesTest& cs) -> void {
+        size_t next_idx = 0;
+        auto existing_strs = cs.expected_location_str;
+        // extend all the location str combos that ended at the boundary of the old input
+        for(const auto& existing_location_str : existing_strs) {
+          // we modify the existing elements when the line view (but not span) overlaps the extended input
+          size_t curr_idx = next_idx;
+          ++next_idx;
+
+          // ... right here:
+          // Locations whose line view (but not span) overlaps the extended part of input must gain a char in their line view.
           {
-            case_pre.input.size(),
+            auto& location_str = cs.expected_location_str.at(curr_idx);
+            // ... but only if our char is not a control char or newline
+            if(cs.input.back() != '\n' && cs.input.back() != '\r') {
+              if(location_str.last_line_idx == cs.curr_line_idx) {
+                location_str.expected_middle += cs.input.back();
+              }
+            }
+          }
+
+          if(existing_location_str.pos + existing_location_str.len + 1 != cs.input.size()) {
+            // skip locations that don't end at the end of the string
+            continue;
+          }
+          auto location_str = existing_location_str;
+          location_str.len += 1;
+
+          if(cs.input.back() == '\n') {
+            if(!location_str.has_newline) {
+              location_str.expected_begin = std::move(location_str.expected_end);
+            }
+            location_str.expected_middle += '\n';
+            location_str.expected_end = ""s;
+            location_str.has_newline = true;
+            location_str.last_line_idx += 1;
+          } else if(cs.input.back() == '\r') {
+            // pass
+          } else if(cs.input.back() == 'a') {
+            // It doesn't matter if there's a newline or not.
+            // Adding a char at the end always grows the '~' at the bottom.
+            location_str.expected_middle += 'a';
+            location_str.expected_end += '~';
+          } else {
+            std::abort();
+          }
+
+          cs.expected_location_str.emplace_back(std::move(location_str));
+        }
+
+        // The one extra case: when we point exactly to the end of the input.
+        {
+          ExpectedLocationStr location_str {
+            cs.input.size(),
+            0,
+            false,
+            cs.curr_line_idx,
+            ""s,
+            cs.last_visible_line,
+            ""s,
+          };
+          for(size_t i = 0; i < cs.last_visible_line.size(); ++i) {
+            location_str.expected_end += ' ';
+          }
+          cs.expected_location_str.emplace_back(std::move(location_str));
+        }
+      };
+
+      if(case_pre.seeking_next_line) {
+        case_pre.seeking_next_line = false;
+        case_pre.last_visible_line = ""s;
+      }
+
+      // The newline character
+      {
+        auto cs = case_pre;
+        cs.input += '\n';
+        cs.expected_linepos.push_back({
+          cs.next_line_idx,
+          {cs.input.size(), 0},
+        });
+        cs.curr_line_idx += 1;
+        cs.next_line_idx += 1;
+        // the linebreak itself is considered to be on the next line
+        cs.expected_linecol.push_back({
+          old_size + 1,
+          {
+            case_pre.expected_linecol.back().expected_linecol.first + 1,
             0,
           },
         });
-        // Also, our linecol(pos = size) case shifts to the beginning of the
-        // next line, now that there is one, as opposed to us trailing off
-        // the end of the last line.
-        case_pre.expected_linecol.back().expected_linecol = {
-          case_pre.line_idx_after, 0};
-      }
+        cs.seeking_next_line = true;
+        // generate all the extra location str prints
+        gen_strs(cs);
 
-      // cover all line break variations
-      for (auto nl : {"\r\n"sv, "\n"sv})
-      {
-        auto cs = case_pre;
-        cs.input += nl;
-        // a) chars after this line break get line number + 1
-        cs.line_idx_after += 1;
-        // b) chars inside the line break stay on the last line, but on extra
-        // columns
-        for (size_t inc = 1; inc <= nl.size(); ++inc)
-        {
-          cs.expected_linecol.push_back({
-            old_size + inc,
-            {
-              case_pre.line_idx_after,
-              case_pre.expected_linecol.back().expected_linecol.second + inc,
-            },
-          });
-        }
-        // c) we don't get a valid next line info if we're a trailing line
-        // break, but the next char will change that
-        cs.was_line_break = true;
         cases.emplace_back(std::move(cs));
       }
-      // not a new line (no need to be imaginative here)
-      {
+      // not a new line:
+      // - character 'a', no need to be imaginative
+      // - character '\r', same effect except for visibility in err strings
+      for(char ch : {'a', '\r'}){
+        if(skip_carriage_returns && ch == '\r') {
+          continue;
+        }
+
         auto cs = case_pre;
-        cs.input += "a"sv;
+        cs.input += ch;
         // a) no change in line_idx_after, following chars still on same line
         // b) queries for info on the last line get a longer span by 1
         cs.expected_linepos.back().expected_linepos.second += 1;
@@ -180,12 +333,21 @@ namespace
         cs.expected_linecol.push_back({
           cs.input.size(),
           {
-            case_pre.line_idx_after,
+            case_pre.expected_linecol.back().expected_linecol.first,
             case_pre.expected_linecol.back().expected_linecol.second + 1,
           },
         });
+        // the carriage return should not be considered "visible"
+        if(ch != '\r') {
+          cs.last_visible_line += ch;
+        }
+        // generate all the extra location str prints
+        gen_strs(cs);
+
         cases.emplace_back(std::move(cs));
       }
+
+
     }
     return cases;
   }
@@ -195,7 +357,11 @@ int main(int argc, char** argv)
 {
   auto app = CLI::App("Tester for Trieste's source location code");
   size_t depth = 0;
+  bool verbose = false;
+  bool skip_carriage_returns = false;
   app.add_option("--depth", depth, "Maximum test string length");
+  app.add_flag("--verbose", verbose, "Print the test cases that were generated.");
+  app.add_flag("--skip-carriage-returns", skip_carriage_returns, "Disable constructing inputs with '\r' in them.");
 
   try
   {
@@ -206,7 +372,25 @@ int main(int argc, char** argv)
     app.exit(err);
   }
 
-  auto cases = build_cases_size_n(depth);
+  std::vector<LinesTest> cases;
+  for(size_t i = 0; i <= depth; ++i) {
+    for(auto&& cs : build_cases_size_n(i, skip_carriage_returns)) {
+      cases.emplace_back(std::move(cs));
+    }
+  } 
+
+  std::cout << "Generated " << cases.size() << " test cases up to depth " << depth << "." << std::endl;
+
+  if(verbose) {
+    size_t idx = 0;
+    for(const auto& cs : cases) {
+      std::cout << std::endl;
+      std::cout << "# Case " << idx << ":" << std::endl;
+      cs.dump();
+      ++idx;
+    }
+    std::cout << std::endl << std::endl;
+  }
 
   for (const auto& cs : cases)
   {


### PR DESCRIPTION
This PR is split off from #126, because really it's an orthogonal fix.

The observed problem was that, on Windows, error messages had a strange `\r` in reported source locations that was inconsistent with both other platforms, and other parts of the same output string (you would see `\n` once then `\r\n` further along the same string).

The trouble was traced back to `source.h`, which was separating lines based on only the `\n` character, and assuming that line breaks were only 1 char wide. This PR rewrites the 3 line/columns handling functions that did this, so that they will accept `\r\n`, `\n`, and `\r` as line delimiters while reporting correct line lengths (and so forth) on all platforms.

The main change of substance is that the `lines` field of `SourceDef` changes from a vector of `size_t` to a vector of `pair<size_t, size_t>`, because it is no longer possible to derive where a line ends from where another line begins (we might have to add/subtract either 1 or 2 chars). Rather than try to detect some file-wide line break width (and possibly have problems due to corrupted files mixing line ending types), this rewrite just looks at which line ending variant each line had and records span information to match.

Additionally, this PR adds exhaustive generative testing of this changed feature.
The test code is commented to explain logically how it builds all possible permutations of line endings and line contents up to a certain length (albeit using just `a` as contents since this code is not sensitive to string contents).
As configured in the `CMakeLists.txt`, it runs 729 test cases up to length 6 (6 chars, 6 line endings, and everything in between).

This fine-grained testing should help keep this code robust if it ever needs to change again - in fact it already helped catch errors when implementing some review recommendations from the other PR this was split from.