### PR TITLE
Use intrusive reference counting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,13 @@ export(EXPORT ${PROJECT_NAME}_Targets
 export(PACKAGE trieste)
 
 # #############################################
+# # Add core Trieste tests
+enable_testing()
+add_subdirectory(test)
+
+# #############################################
 # # Add samples
 if(TRIESTE_BUILD_SAMPLES)
-  enable_testing()
   add_subdirectory(samples/infix)
 endif()
 

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -937,18 +937,6 @@ namespace trieste
     }
   };
 
-  constexpr void
-  intrusive_refcounted_traits<NodeDef>::intrusive_inc_ref(NodeDef* node)
-  {
-    node->intrusive_inc_ref();
-  }
-
-  constexpr void
-  intrusive_refcounted_traits<NodeDef>::intrusive_dec_ref(NodeDef* node)
-  {
-    node->intrusive_dec_ref();
-  }
-
   inline TokenDef::operator Node() const
   {
     return NodeDef::create(Token(*this));

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -407,7 +407,7 @@ namespace trieste
 
     auto find_first(Token token, NodeIt begin)
     {
-      assert((*begin)->parent() == this);   
+      assert((*begin)->parent() == this);
       return std::find_if(
         begin, children.end(), [token](auto& n) { return n->type() == token; });
     }
@@ -937,7 +937,17 @@ namespace trieste
     }
   };
 
+  constexpr void
+  intrusive_refcounted_traits<NodeDef>::intrusive_inc_ref(NodeDef* node)
+  {
+    node->intrusive_inc_ref();
+  }
 
+  constexpr void
+  intrusive_refcounted_traits<NodeDef>::intrusive_dec_ref(NodeDef* node)
+  {
+    node->intrusive_dec_ref();
+  }
 
   inline TokenDef::operator Node() const
   {

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -196,7 +196,7 @@ namespace trieste
     : type_(type), location_(location), parent_(nullptr)
     {
       if (type_ & flag::symtab)
-        symtab_ = intrusive_ptr(new SymtabDef());
+        symtab_ = Symtab::make();
     }
 
     void add_flags()
@@ -292,12 +292,12 @@ namespace trieste
 
     static Node create(const Token& type)
     {
-      return intrusive_ptr{new NodeDef(type, {nullptr, 0, 0})};
+      return Node(new NodeDef(type, Location{nullptr, 0, 0}));
     }
 
     static Node create(const Token& type, Location location)
     {
-      return intrusive_ptr{new NodeDef(type, location)};
+      return Node(new NodeDef(type, location));
     }
 
     static Node create(const Token& type, NodeRange range)
@@ -305,8 +305,8 @@ namespace trieste
       if (range.empty())
         return create(type);
 
-      return intrusive_ptr{
-        new NodeDef(type, range.front()->location_ * range.back()->location_)};
+      return Node(
+        new NodeDef(type, range.front()->location_ * range.back()->location_));
     }
 
     const Token& type() const

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -937,6 +937,18 @@ namespace trieste
     }
   };
 
+  constexpr void
+  intrusive_refcounted_traits<NodeDef>::intrusive_inc_ref(NodeDef* node)
+  {
+    node->intrusive_inc_ref();
+  }
+
+  constexpr void
+  intrusive_refcounted_traits<NodeDef>::intrusive_dec_ref(NodeDef* node)
+  {
+    node->intrusive_dec_ref();
+  }
+
   inline TokenDef::operator Node() const
   {
     return NodeDef::create(Token(*this));

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -37,7 +37,7 @@ namespace trieste
         return value;
       }
 
-      copyable_refcount operator+=(size_t inc)
+      copyable_refcount& operator+=(size_t inc)
       {
         value += inc;
         return *this;

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -26,14 +26,11 @@ namespace trieste
     SNMALLOC_SLOW_PATH
     constexpr void intrusive_dec_ref()
     {
-      if (intrusive_refcount == 1)
+      assert(intrusive_refcount > 0);
+      intrusive_refcount -= 1;
+      if (intrusive_refcount == 0)
       {
-        intrusive_refcount = 0;
         delete this;
-      }
-      else
-      {
-        intrusive_refcount -= 1;
       }
     }
 
@@ -111,8 +108,8 @@ namespace trieste
 
     constexpr intrusive_ptr<T>& operator=(const intrusive_ptr<T>& other)
     {
-      // Sets us to nullptr and holds onto our ptr in tmp
-      intrusive_ptr<T> tmp = std::move(*this);
+      // Hold onto our ptr until we return, adding 1 to refcount
+      intrusive_ptr<T> tmp{*this};
       ptr = other.ptr;
       inc_ref();
       // dec_ref for our original ptr goes here, where tmp gets destroyed.
@@ -125,7 +122,6 @@ namespace trieste
     constexpr intrusive_ptr<T>& operator=(intrusive_ptr<T>&& other)
     {
       std::swap(ptr, other.ptr);
-      other.dec_ref();
       return *this;
     }
 

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -70,7 +70,7 @@ namespace trieste
   private:
     T* ptr;
 
-    constexpr void inc_ref()
+    constexpr void inc_ref() const
     {
       if (ptr)
       {
@@ -127,20 +127,25 @@ namespace trieste
       {
         return *this;
       }
+      // Increment other's refcount before copying the ptr
+      other.inc_ref();
 
       intrusive_ptr<T> tmp;
       // Don't actually inc_ref, but putting old ptr in tmp lets us leverage the
       // built in dec_ref with null checks below.
       tmp.ptr = ptr;
+
       ptr = other.ptr;
-      inc_ref();
       // tmp gets dec_ref here, potentially destroying the value at old ptr
       return *this;
     }
 
     constexpr intrusive_ptr<T>& operator=(intrusive_ptr<T>&& other)
     {
-      std::swap(ptr, other.ptr);
+      intrusive_ptr<T> old;
+      old.ptr = ptr;
+      ptr = other.ptr;
+      other.ptr = nullptr;
       return *this;
     }
 

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -23,7 +23,7 @@ namespace trieste
     struct copyable_refcount final
     {
     private:
-      std::atomic<size_t> value = 0;
+      std::atomic<size_t> value{0};
 
     public:
       constexpr copyable_refcount(size_t value_) : value{value_} {}
@@ -198,7 +198,7 @@ namespace trieste
   struct intrusive_refcounted
   {
   private:
-    detail::copyable_refcount intrusive_refcount = 0;
+    detail::copyable_refcount intrusive_refcount{0};
 
     constexpr void intrusive_inc_ref()
     {

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -1,0 +1,298 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <ostream>
+#include <type_traits>
+#include <utility>
+
+namespace trieste
+{
+  struct intrusive_refcounted_blk
+  {
+  private:
+    size_t intrusive_refcount = 0;
+
+    constexpr void intrusive_inc_ref()
+    {
+      intrusive_refcount += 1;
+    }
+
+    constexpr void intrusive_dec_ref()
+    {
+      if (intrusive_refcount == 1)
+      {
+        intrusive_refcount = 0;
+        delete this;
+      }
+      else
+      {
+        intrusive_refcount -= 1;
+      }
+    }
+
+  public:
+    template<typename T>
+    friend struct intrusive_ptr;
+
+    // impl note:
+    // This is virtual, because Trieste relies heavily on being able to
+    // use incomplete types in these pointers.
+    // The vtable replaces shared_ptr's way of tolerating that, by allowing
+    // the compiler to emit vtable lookups when it wants to
+    // call the destructor, rather than run into undefined behavior.
+
+    constexpr virtual ~intrusive_refcounted_blk()
+    {
+      assert(intrusive_refcount == 0);
+    }
+  };
+
+  template<typename T>
+  struct intrusive_ptr final
+  {
+  private:
+    intrusive_refcounted_blk* ptr;
+
+    constexpr void inc_ref()
+    {
+      if (ptr)
+      {
+        ptr->intrusive_inc_ref();
+      }
+    }
+    constexpr void dec_ref()
+    {
+      if (ptr)
+      {
+        ptr->intrusive_dec_ref();
+        ptr = nullptr;
+      }
+    }
+
+  public:
+    constexpr intrusive_ptr() : ptr{nullptr} {}
+
+    constexpr intrusive_ptr(std::nullptr_t) : ptr{nullptr} {}
+
+    constexpr explicit intrusive_ptr(T* ptr_) : ptr{ptr_}
+    {
+      inc_ref();
+    }
+
+    template<typename U>
+    constexpr intrusive_ptr(const intrusive_ptr<U>& other) : ptr{other.get()}
+    {
+      inc_ref();
+    }
+
+    template<typename U>
+    constexpr intrusive_ptr(intrusive_ptr<U>&& other) : ptr{other.get()}
+    {
+      other.release();
+    }
+
+    constexpr intrusive_ptr(const intrusive_ptr<T>& other) : ptr{other.ptr}
+    {
+      inc_ref();
+    }
+
+    constexpr intrusive_ptr(intrusive_ptr<T>&& other) : ptr{nullptr}
+    {
+      std::swap(ptr, other.ptr);
+    }
+
+    constexpr intrusive_ptr<T>& operator=(const intrusive_ptr<T>& other)
+    {
+      // Sets us to nullptr and holds onto our ptr in tmp
+      intrusive_ptr<T> tmp = std::move(*this);
+      ptr = other.ptr;
+      inc_ref();
+      // dec_ref for our original ptr goes here, where tmp gets destroyed.
+      // If ptr == other.ptr, this ensures we don't accidentally delete ptr
+      // on self-assignment because refcount never hits 0 (it goes 1, 2, 1
+      // instead).
+      return *this;
+    }
+
+    constexpr intrusive_ptr<T>& operator=(intrusive_ptr<T>&& other)
+    {
+      std::swap(ptr, other.ptr);
+      other.dec_ref();
+      return *this;
+    }
+
+    constexpr void swap(intrusive_ptr<T>& other)
+    {
+      std::swap(ptr, other.ptr);
+    }
+
+    constexpr void reset()
+    {
+      dec_ref();
+    }
+
+    constexpr T* get() const
+    {
+      // our "runtime check" for this being ok is by construction
+      // of the pointer itself.
+      // We can't have been given some U* that is not valid to static_cast to
+      // T*, because none of our methods allow it.
+      return static_cast<T*>(ptr);
+    }
+
+    constexpr T* operator->() const
+    {
+      return get();
+    }
+
+    constexpr T& operator*() const
+    {
+      return *get();
+    }
+
+    constexpr operator bool() const
+    {
+      return ptr;
+    }
+
+    constexpr T* release()
+    {
+      auto p = get();
+      ptr = nullptr;
+      return p;
+    }
+
+    constexpr ~intrusive_ptr()
+    {
+      dec_ref();
+    }
+
+    friend std::hash<intrusive_ptr<T>>;
+  };
+
+  template<typename T, typename U>
+  constexpr intrusive_ptr<U> static_pointer_cast(const intrusive_ptr<T>& ptr)
+  {
+    return intrusive_ptr(static_cast<U*>(ptr.get()));
+  }
+
+  template<typename T, typename U>
+  constexpr intrusive_ptr<U> dynamic_pointer_cast(const intrusive_ptr<T>& ptr)
+  {
+    // nullptr dynamic_cast case handled: constructor tolerates it anyway
+    return intrusive_ptr(dynamic_cast<U*>(ptr.get()));
+  }
+
+  template<typename T, typename U>
+  constexpr intrusive_ptr<U> const_pointer_cast(const intrusive_ptr<T>& ptr)
+  {
+    return intrusive_ptr(const_cast<U*>(ptr.get()));
+  }
+
+  // impl note:
+  // It is important that these functions are non-member template functions.
+  // If you make them just member functions, they clash with operator==(Node,
+  // const Token&) defined elsewhere.
+
+  template<typename T, typename U>
+  constexpr bool
+  operator==(const intrusive_ptr<T>& lhs, const intrusive_ptr<U>& rhs)
+  {
+    return lhs.get() == rhs.get();
+  }
+
+  template<typename T>
+  constexpr bool operator==(const intrusive_ptr<T>& lhs, std::nullptr_t)
+  {
+    return lhs.get() == nullptr;
+  }
+
+  template<typename T>
+  constexpr bool operator==(std::nullptr_t, const intrusive_ptr<T>& rhs)
+  {
+    return nullptr == rhs.get();
+  }
+
+  template<typename T, typename U>
+  constexpr bool
+  operator!=(const intrusive_ptr<T>& lhs, const intrusive_ptr<U>& rhs)
+  {
+    return lhs.get() != rhs.get();
+  }
+
+  template<typename T>
+  constexpr bool operator!=(const intrusive_ptr<T>& lhs, std::nullptr_t)
+  {
+    return lhs.get() != nullptr;
+  }
+
+  template<typename T>
+  constexpr bool operator!=(std::nullptr_t, const intrusive_ptr<T>& rhs)
+  {
+    return nullptr != rhs.get();
+  }
+
+  template<typename T, typename U>
+  constexpr bool
+  operator<(const intrusive_ptr<T>& lhs, const intrusive_ptr<U>& rhs)
+  {
+    return lhs.get() < rhs.get();
+  }
+
+  template<typename T, typename U>
+  constexpr bool
+  operator>(const intrusive_ptr<T>& lhs, const intrusive_ptr<U>& rhs)
+  {
+    return lhs.get() > rhs.get();
+  }
+
+  template<typename T, typename U>
+  constexpr bool
+  operator<=(const intrusive_ptr<T>& lhs, const intrusive_ptr<U>& rhs)
+  {
+    return lhs.get() <= rhs.get();
+  }
+
+  template<typename T, typename U>
+  constexpr bool
+  operator>=(const intrusive_ptr<T>& lhs, const intrusive_ptr<U>& rhs)
+  {
+    return lhs.get() >= rhs.get();
+  }
+
+  template<typename T>
+  std::ostream& operator<<(std::ostream& os, const intrusive_ptr<T> ptr)
+  {
+    return os << ptr.get();
+  }
+
+  template<typename T>
+  struct intrusive_refcounted : public intrusive_refcounted_blk
+  {
+  public:
+    constexpr intrusive_ptr<T> intrusive_ptr_from_this()
+    {
+      return intrusive_ptr{static_cast<T*>(this)};
+    }
+  };
+}
+
+namespace std
+{
+  template<typename T>
+  struct hash<trieste::intrusive_ptr<T>>
+  {
+    size_t operator()(const trieste::intrusive_ptr<T> ptr) const
+    {
+      return std::hash<T*>{}(ptr.ptr);
+    }
+  };
+
+  template<typename T>
+  void swap(trieste::intrusive_ptr<T>& lhs, trieste::intrusive_ptr<T>& rhs)
+  {
+    lhs.swap(rhs);
+  }
+}

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "snmalloc/ds_core/defines.h"
+
 #include <cassert>
 #include <cstddef>
 #include <functional>
 #include <ostream>
-#include <type_traits>
 #include <utility>
 
 namespace trieste
@@ -19,6 +20,10 @@ namespace trieste
       intrusive_refcount += 1;
     }
 
+    // It's better to have the non-null case dec_ref code all in one place,
+    // because it's long for something that might be pasted over 10x
+    // into functions that use intrusive_ptr a lot.
+    SNMALLOC_SLOW_PATH
     constexpr void intrusive_dec_ref()
     {
       if (intrusive_refcount == 1)
@@ -62,6 +67,7 @@ namespace trieste
         ptr->intrusive_inc_ref();
       }
     }
+
     constexpr void dec_ref()
     {
       if (ptr)

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -87,15 +87,21 @@ namespace trieste
     }
 
     template<typename U>
-    constexpr intrusive_ptr(const intrusive_ptr<U>& other) : ptr{other.get()}
+    constexpr intrusive_ptr(const intrusive_ptr<U>& other) : ptr{nullptr}
     {
+      // enforce U* to T* compatibility
+      T* tmp = other.get();
+      ptr = tmp;
       inc_ref();
     }
 
     template<typename U>
-    constexpr intrusive_ptr(intrusive_ptr<U>&& other) : ptr{other.get()}
+    constexpr intrusive_ptr(intrusive_ptr<U>&& other) : ptr{nullptr}
     {
-      other.release();
+      // to enforce the pointer compatibility (from U* to T* to
+      // intrusive_refcounted_blk*)
+      T* tmp = other.release();
+      ptr = tmp;
     }
 
     constexpr intrusive_ptr(const intrusive_ptr<T>& other) : ptr{other.ptr}

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -11,6 +11,60 @@
 
 namespace trieste
 {
+  namespace detail
+  {
+    // In principle, std::atomic should not be copied.
+    // It should be a single object that is pointer-to and manipulated by
+    // multiple threads. For refcounts however, it should be possible to copy a
+    // refcounted object. The catch is that _everything but the refcount should
+    // be copied_. The copy constructors here will just set the new refcount to
+    // 0, as if the object was constructed from scratch, so different
+    // intrusive_ptr can take ownership of the new object.
+    struct copyable_refcount final
+    {
+    private:
+      // The refcount here starts at 0, not 1 like in other reference counting
+      // systems. It's because we're not even sure we're reference counting a
+      // heap allocated object at all.
+      //
+      // The reference count is embedded into a user-allocatable object that can
+      // (and does in this codebase) live on the stack in some cases. If a
+      // pointer to an intrusive_refcounted is given to an intrusive_ptr, then
+      // its refcount is incremented to 1, and it becomes managed as a
+      // reference-counted object. If not, it is convenient to start and keep
+      // the refcount at 0 - no intrusive_ptr should point to a stack-allocated
+      // intrusive_refcounted. Also, we assert that the end refcount of a
+      // destroyed intrusive_refcounted is 0, and starting at 1 would prevent
+      // that assertion from holding in general.
+      static constexpr size_t refcount_init = 0;
+      std::atomic<size_t> value;
+
+    public:
+      constexpr copyable_refcount(size_t value_) : value{value_} {}
+
+      constexpr copyable_refcount() : value{refcount_init} {}
+      constexpr copyable_refcount(const copyable_refcount&)
+      : value{refcount_init}
+      {}
+
+      operator size_t() const
+      {
+        return value;
+      }
+
+      copyable_refcount& operator+=(size_t inc)
+      {
+        value += inc;
+        return *this;
+      }
+
+      size_t fetch_sub(size_t dec)
+      {
+        return value.fetch_sub(dec);
+      }
+    };
+  }
+
   template<typename T>
   struct intrusive_refcounted_traits
   {
@@ -159,21 +213,16 @@ namespace trieste
   struct intrusive_refcounted
   {
   private:
-    // The refcount here starts at 0, not 1 like in other reference counting
-    // systems. It's because we're not even sure we're reference counting a
-    // heap allocated object at all.
+    // See docs on this type for an explanation of its unusual refcounting
+    // semantics.
     //
-    // The reference count is embedded into a user-allocatable object that can
-    // (and does in this codebase) live on the stack in some cases. If a
-    // pointer to an intrusive_refcounted is given to an intrusive_ptr, then
-    // its refcount is incremented to 1, and it becomes managed as a
-    // reference-counted object. If not, it is convenient to start and keep
-    // the refcount at 0 - no intrusive_ptr should point to a stack-allocated
-    // intrusive_refcounted. Also, we assert that the end refcount of a
-    // destroyed intrusive_refcounted is 0, and starting at 1 would prevent
-    // that assertion from holding in general.
-    static constexpr size_t refcount_init = 0;
-    std::atomic<size_t> intrusive_refcount;
+    // Note: this is a separate type because it allows subclasses to ignore it.
+    // Any generated copy/default constructors will call into it properly, and
+    // if a hand-written copy constructor ignores it, it will be silently
+    // default initialized. It is always necessary to make a fresh refcount for
+    // a fresh object, so it's fine to ignore copy semantics here - it makes no
+    // difference to what will happen.
+    detail::copyable_refcount intrusive_refcount;
 
     constexpr void intrusive_inc_ref()
     {
@@ -202,20 +251,6 @@ namespace trieste
   public:
     template<typename>
     friend struct intrusive_refcounted_traits;
-
-    // When we copy an intrusive_refcounted object, the refcount must not be
-    // copied. It must be reset, because now we have 2 objects with separate
-    // ownership, lifetime, and so forth.
-    //
-    // Point of confusion: if you write your own copy constructor in a subclass,
-    // you don't have to call this superclass's copy constructor. If you just
-    // write your copy constructor as if this superclass didn't exist, the
-    // refcount will be default-initialized, which is what the copy constructor
-    // does anyway if you invoke it.
-    constexpr intrusive_refcounted() : intrusive_refcount{refcount_init} {}
-    constexpr intrusive_refcounted(const intrusive_refcounted<T>&)
-    : intrusive_refcount{refcount_init}
-    {}
 
     constexpr intrusive_ptr<T> intrusive_ptr_from_this()
     {

--- a/include/trieste/intrusive_ptr.h
+++ b/include/trieste/intrusive_ptr.h
@@ -32,18 +32,18 @@ namespace trieste
       constexpr copyable_refcount(const copyable_refcount&) : value{0} {}
       constexpr copyable_refcount(copyable_refcount&&) : value{0} {}
 
-      constexpr operator size_t() const
+      operator size_t() const
       {
         return value;
       }
 
-      constexpr copyable_refcount operator+=(size_t inc)
+      copyable_refcount operator+=(size_t inc)
       {
         value += inc;
         return *this;
       }
 
-      constexpr size_t fetch_sub(size_t dec)
+      size_t fetch_sub(size_t dec)
       {
         return value.fetch_sub(dec);
       }

--- a/include/trieste/parse.h
+++ b/include/trieste/parse.h
@@ -534,13 +534,13 @@ namespace trieste
   inline detail::Rule
   operator>>(detail::Located<const std::string&> s, detail::ParseEffect effect)
   {
-    return intrusive_ptr(new detail::RuleDef(s, effect));
+    return detail::Rule::make(s, effect);
   }
 
   inline detail::Rule
   operator>>(detail::Located<const char*> s, detail::ParseEffect effect)
   {
-    return intrusive_ptr(new detail::RuleDef(s, effect));
+    return detail::Rule::make(s, effect);
   }
 
   inline std::pair<Token, GenLocationF>

--- a/include/trieste/parse.h
+++ b/include/trieste/parse.h
@@ -7,6 +7,7 @@
 #include "gen.h"
 #include "logging.h"
 #include "regex.h"
+#include "trieste/intrusive_ptr.h"
 #include "wf.h"
 
 #include <filesystem>
@@ -22,7 +23,7 @@ namespace trieste
     class Make;
     using ParseEffect = std::function<void(Make&)>;
 
-    class RuleDef
+    class RuleDef final : public intrusive_refcounted<RuleDef>
     {
       friend class trieste::Parse;
 
@@ -41,7 +42,7 @@ namespace trieste
       {}
     };
 
-    using Rule = std::shared_ptr<RuleDef>;
+    using Rule = intrusive_ptr<RuleDef>;
 
     class Make
     {
@@ -139,7 +140,7 @@ namespace trieste
         while (node->parent()->type().in(skip))
         {
           extend();
-          node = node->parent()->shared_from_this();
+          node = node->parent()->intrusive_ptr_from_this();
         }
 
         extend();
@@ -147,7 +148,7 @@ namespace trieste
 
         if (p == type)
         {
-          node = p->shared_from_this();
+          node = p->intrusive_ptr_from_this();
         }
         else
         {
@@ -215,7 +216,7 @@ namespace trieste
         {
           extend();
 
-          node = node->parent()->shared_from_this();
+          node = node->parent()->intrusive_ptr_from_this();
           return true;
         }
 
@@ -244,7 +245,7 @@ namespace trieste
         {
           node->push_back(make_error(node->location(), "this is unclosed"));
           term();
-          node = node->parent()->shared_from_this();
+          node = node->parent()->intrusive_ptr_from_this();
           term();
         }
 
@@ -533,13 +534,13 @@ namespace trieste
   inline detail::Rule
   operator>>(detail::Located<const std::string&> s, detail::ParseEffect effect)
   {
-    return std::make_shared<detail::RuleDef>(s, effect);
+    return intrusive_ptr(new detail::RuleDef(s, effect));
   }
 
   inline detail::Rule
   operator>>(detail::Located<const char*> s, detail::ParseEffect effect)
   {
-    return std::make_shared<detail::RuleDef>(s, effect);
+    return intrusive_ptr(new detail::RuleDef(s, effect));
   }
 
   inline std::pair<Token, GenLocationF>

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -89,7 +89,7 @@ namespace trieste
 
     operator Pass() const
     {
-      return intrusive_ptr(new PassDef(std::move(*this)));
+      return Pass::make(std::move(*this));
     }
 
     const std::string& name()

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -2,6 +2,7 @@
 
 #include "defaultmap.h"
 #include "rewrite.h"
+#include "trieste/intrusive_ptr.h"
 #include "wf.h"
 
 #include <vector>
@@ -17,9 +18,9 @@ namespace trieste
   }
 
   class PassDef;
-  using Pass = std::shared_ptr<PassDef>;
+  using Pass = intrusive_ptr<PassDef>;
 
-  class PassDef
+  class PassDef : public intrusive_refcounted<PassDef>
   {
   public:
     using F = std::function<size_t(Node)>;
@@ -88,7 +89,7 @@ namespace trieste
 
     operator Pass() const
     {
-      return std::make_shared<PassDef>(std::move(*this));
+      return intrusive_ptr(new PassDef(std::move(*this)));
     }
 
     const std::string& name()

--- a/include/trieste/regex.h
+++ b/include/trieste/regex.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "logging.h"
-#include "source.h"
+#include "ast.h"
 
 #include <re2/re2.h>
 
@@ -186,7 +186,7 @@ namespace trieste
         if (!parent)
           return ast;
 
-        ast = parent->shared_from_this();
+        ast = parent->intrusive_ptr_from_this();
       }
     }
 

--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -388,7 +388,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Cap(*this));
+        return intrusive_ptr<Cap>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -410,7 +410,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Anything(*this));
+        return intrusive_ptr<Anything>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -434,7 +434,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new TokenMatch(*this));
+        return intrusive_ptr<TokenMatch>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -476,7 +476,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new RegexMatch(*this));
+        return intrusive_ptr<RegexMatch>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -507,7 +507,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Opt(*this));
+        return intrusive_ptr<Opt>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -538,7 +538,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Rep(*this));
+        return intrusive_ptr<Rep>::make(*this);
       }
 
       PatternPtr custom_rep() override
@@ -578,7 +578,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Not(*this));
+        return intrusive_ptr<Not>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -617,7 +617,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Choice(*this));
+        return intrusive_ptr<Choice>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -656,7 +656,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new InsideStar(*this));
+        return intrusive_ptr<InsideStar>::make(*this);
       }
 
       PatternPtr custom_rep() override
@@ -693,14 +693,14 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Inside(*this));
+        return intrusive_ptr<Inside>::make(*this);
       }
 
       PatternPtr custom_rep() override
       {
         // Rep(Inside) -> InsideStar
         if (no_continuation())
-          return intrusive_ptr(new InsideStar<N>(types));
+          return intrusive_ptr<InsideStar<N>>::make(types);
         return {};
       }
 
@@ -723,7 +723,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new First(*this));
+        return intrusive_ptr<First>::make(*this);
       }
 
       PatternPtr custom_rep() override
@@ -744,7 +744,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Last(*this));
+        return intrusive_ptr<Last>::make(*this);
       }
 
       PatternPtr custom_rep() override
@@ -777,7 +777,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Children(*this));
+        return intrusive_ptr<Children>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -811,7 +811,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Pred(*this));
+        return intrusive_ptr<Pred>::make(*this);
       }
 
       PatternPtr custom_rep() override
@@ -842,7 +842,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new NegPred(*this));
+        return intrusive_ptr<NegPred>::make(*this);
       }
 
       PatternPtr custom_rep() override
@@ -872,7 +872,7 @@ namespace trieste
 
       PatternPtr clone() const& override
       {
-        return intrusive_ptr(new Action(*this));
+        return intrusive_ptr<Action>::make(*this);
       }
 
       bool match(NodeIt& it, const Node& parent, Match& match) const& override
@@ -916,30 +916,31 @@ namespace trieste
       Pattern operator()(F&& action) const
       {
         return {
-          intrusive_ptr(new Action<F>(std::forward<F>(action), pattern)),
+          intrusive_ptr<Action<F>>::make(std::forward<F>(action), pattern),
           fast_pattern};
       }
 
       Pattern operator[](const Token& name) const
       {
-        return {intrusive_ptr(new Cap(name, pattern)), fast_pattern};
+        return {intrusive_ptr<Cap>::make(name, pattern), fast_pattern};
       }
 
       Pattern operator~() const
       {
         return {
-          intrusive_ptr(new Opt(pattern)),
+          intrusive_ptr<Opt>::make(pattern),
           FastPattern::match_opt(fast_pattern)};
       }
 
       Pattern operator++() const
       {
-        return {intrusive_ptr(new Pred(pattern)), FastPattern::match_pred()};
+        return {intrusive_ptr<Pred>::make(pattern), FastPattern::match_pred()};
       }
 
       Pattern operator--() const
       {
-        return {intrusive_ptr(new NegPred(pattern)), FastPattern::match_pred()};
+        return {
+          intrusive_ptr<NegPred>::make(pattern), FastPattern::match_pred()};
       }
 
       Pattern operator++(int) const
@@ -951,13 +952,13 @@ namespace trieste
           return {result, FastPattern::match_any()};
 
         return {
-          intrusive_ptr(new Rep(pattern)),
+          intrusive_ptr<Rep>::make(pattern),
           FastPattern::match_opt(fast_pattern)};
       }
 
       Pattern operator!() const
       {
-        return {intrusive_ptr(new Not(pattern)), FastPattern::match_pred()};
+        return {intrusive_ptr<Not>::make(pattern), FastPattern::match_pred()};
       }
 
       Pattern operator*(Pattern rhs) const
@@ -978,24 +979,24 @@ namespace trieste
           tokens.insert(tokens.end(), lhs_tokens.begin(), lhs_tokens.end());
           tokens.insert(tokens.end(), rhs_tokens.begin(), rhs_tokens.end());
           return {
-            intrusive_ptr(new TokenMatch(tokens)),
+            intrusive_ptr<TokenMatch>::make(tokens),
             FastPattern::match_choice(fast_pattern, rhs.fast_pattern)};
         }
 
         if (pattern->has_captures())
           return {
-            intrusive_ptr(new Choice<true>(pattern, rhs.pattern)),
+            intrusive_ptr<Choice<true>>::make(pattern, rhs.pattern),
             FastPattern::match_choice(fast_pattern, rhs.fast_pattern)};
         else
           return {
-            intrusive_ptr(new Choice<false>(pattern, rhs.pattern)),
+            intrusive_ptr<Choice<false>>::make(pattern, rhs.pattern),
             FastPattern::match_choice(fast_pattern, rhs.fast_pattern)};
       }
 
       Pattern operator<<(Pattern rhs) const
       {
         return {
-          intrusive_ptr(new Children(pattern, rhs.pattern)), fast_pattern};
+          intrusive_ptr<Children>::make(pattern, rhs.pattern), fast_pattern};
       }
 
       const std::set<Token>& get_starts() const
@@ -1042,17 +1043,17 @@ namespace trieste
   }
 
   inline const auto Any = detail::Pattern(
-    intrusive_ptr(new detail::Anything()), detail::FastPattern::match_any());
+    intrusive_ptr<detail::Anything>::make(), detail::FastPattern::match_any());
   inline const auto Start = detail::Pattern(
-    intrusive_ptr(new detail::First()), detail::FastPattern::match_pred());
+    intrusive_ptr<detail::First>::make(), detail::FastPattern::match_pred());
   inline const auto End = detail::Pattern(
-    intrusive_ptr(new detail::Last()), detail::FastPattern::match_pred());
+    intrusive_ptr<detail::Last>::make(), detail::FastPattern::match_pred());
 
   inline detail::Pattern T(const Token& type)
   {
     std::vector<Token> types = {type};
     return detail::Pattern(
-      intrusive_ptr(new detail::TokenMatch(types)),
+      intrusive_ptr<detail::TokenMatch>::make(types),
       detail::FastPattern::match_token({type}));
   }
 
@@ -1062,14 +1063,14 @@ namespace trieste
   {
     std::vector<Token> types_ = {type1, type2, types...};
     return detail::Pattern(
-      intrusive_ptr(new detail::TokenMatch(types_)),
+      intrusive_ptr<detail::TokenMatch>::make(types_),
       detail::FastPattern::match_token({type1, type2, types...}));
   }
 
   inline detail::Pattern T(const Token& type, const std::string& r)
   {
     return detail::Pattern(
-      intrusive_ptr(new detail::RegexMatch(type, r)),
+      intrusive_ptr<detail::RegexMatch>::make(type, r),
       detail::FastPattern::match_token({type}));
   }
 
@@ -1078,7 +1079,7 @@ namespace trieste
   {
     std::array<Token, 1 + sizeof...(types)> types_ = {type1, types...};
     return detail::Pattern(
-      intrusive_ptr(new detail::Inside<1 + sizeof...(types)>(types_)),
+      intrusive_ptr<detail::Inside<1 + sizeof...(types)>>::make(types_),
       detail::FastPattern::match_parent({type1, types...}));
   }
 

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -18,6 +18,18 @@ namespace trieste
   class SourceDef;
   struct Location;
   class NodeDef;
+
+  // Because NodeDef is an incomplete type for a while, we need to explicitly
+  // defer trying to express its refcount increment and decrement (or we get
+  // incomplete type error). The two functions that are not implemented here can
+  // be found under NodeDef's definition.
+  template<>
+  struct intrusive_refcounted_traits<NodeDef>
+  {
+    static constexpr void intrusive_inc_ref(NodeDef*);
+    static constexpr void intrusive_dec_ref(NodeDef*);
+  };
+
   using Source = intrusive_ptr<SourceDef>;
   using Node = intrusive_ptr<NodeDef>;
 

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -51,7 +51,7 @@ namespace trieste
       auto size = f.tellg();
       f.seekg(0, std::ios::beg);
 
-      auto source = intrusive_ptr{new SourceDef()};
+      auto source = Source::make();
       source->origin_ = std::filesystem::relative(file).string();
       source->contents.resize(static_cast<std::size_t>(size));
       f.read(&source->contents[0], size);
@@ -65,7 +65,7 @@ namespace trieste
 
     static Source synthetic(const std::string& contents)
     {
-      auto source = intrusive_ptr{new SourceDef()};
+      auto source = Source::make();
       source->contents = contents;
       source->find_lines();
       return source;

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -17,21 +17,8 @@ namespace trieste
 {
   class SourceDef;
   struct Location;
-  class NodeDef;
-
-  // Because NodeDef is an incomplete type for a while, we need to explicitly
-  // defer trying to express its refcount increment and decrement (or we get
-  // incomplete type error). The two functions that are not implemented here can
-  // be found under NodeDef's definition.
-  template<>
-  struct intrusive_refcounted_traits<NodeDef>
-  {
-    static constexpr void intrusive_inc_ref(NodeDef*);
-    static constexpr void intrusive_dec_ref(NodeDef*);
-  };
 
   using Source = intrusive_ptr<SourceDef>;
-  using Node = intrusive_ptr<NodeDef>;
 
   class SourceDef final : public intrusive_refcounted<SourceDef>
   {
@@ -126,8 +113,6 @@ namespace trieste
       }
     }
   };
-
-  using Source = intrusive_ptr<SourceDef>;
 
   struct Location
   {

--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "intrusive_ptr.h"
+
 #include <algorithm>
 #include <cassert>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
-#include <memory>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace trieste
@@ -18,10 +18,10 @@ namespace trieste
   class SourceDef;
   struct Location;
   class NodeDef;
-  using Source = std::shared_ptr<SourceDef>;
-  using Node = std::shared_ptr<NodeDef>;
+  using Source = intrusive_ptr<SourceDef>;
+  using Node = intrusive_ptr<NodeDef>;
 
-  class SourceDef
+  class SourceDef final : public intrusive_refcounted<SourceDef>
   {
   private:
     std::string origin_;
@@ -39,7 +39,7 @@ namespace trieste
       auto size = f.tellg();
       f.seekg(0, std::ios::beg);
 
-      auto source = std::make_shared<SourceDef>();
+      auto source = intrusive_ptr{new SourceDef()};
       source->origin_ = std::filesystem::relative(file).string();
       source->contents.resize(static_cast<std::size_t>(size));
       f.read(&source->contents[0], size);
@@ -53,7 +53,7 @@ namespace trieste
 
     static Source synthetic(const std::string& contents)
     {
-      auto source = std::make_shared<SourceDef>();
+      auto source = intrusive_ptr{new SourceDef()};
       source->contents = contents;
       source->find_lines();
       return source;
@@ -114,6 +114,8 @@ namespace trieste
       }
     }
   };
+
+  using Source = intrusive_ptr<SourceDef>;
 
   struct Location
   {

--- a/include/trieste/token.h
+++ b/include/trieste/token.h
@@ -10,6 +10,21 @@
 
 namespace trieste
 {
+  class NodeDef;
+
+  // Because NodeDef is an incomplete type in this file, we need to explicitly
+  // defer trying to express its refcount increment and decrement (or we get
+  // incomplete type error). The two functions that are not implemented here can
+  // be found under NodeDef's definition.
+  template<>
+  struct intrusive_refcounted_traits<NodeDef>
+  {
+    static constexpr void intrusive_inc_ref(NodeDef*);
+    static constexpr void intrusive_dec_ref(NodeDef*);
+  };
+
+  using Node = intrusive_ptr<NodeDef>;
+
   struct TokenDef;
   struct Token;
 

--- a/include/trieste/token.h
+++ b/include/trieste/token.h
@@ -11,6 +11,18 @@
 namespace trieste
 {
   class NodeDef;
+
+  // Because NodeDef is an incomplete type in this file, we need to explicitly
+  // defer trying to express its refcount increment and decrement (or we get
+  // incomplete type error). The two functions that are not implemented here can
+  // be found under NodeDef's definition.
+  template<>
+  struct intrusive_refcounted_traits<NodeDef>
+  {
+    static constexpr void intrusive_inc_ref(NodeDef*);
+    static constexpr void intrusive_dec_ref(NodeDef*);
+  };
+
   using Node = intrusive_ptr<NodeDef>;
 
   struct TokenDef;

--- a/include/trieste/token.h
+++ b/include/trieste/token.h
@@ -12,10 +12,13 @@ namespace trieste
 {
   class NodeDef;
 
-  // Because NodeDef is an incomplete type in this file, we need to explicitly
-  // defer trying to express its refcount increment and decrement (or we get
-  // incomplete type error). The two functions that are not implemented here can
-  // be found under NodeDef's definition.
+  // Certain uses of the Node alias before the full definition of NodeDef can
+  // cause incomplete type errors, so this manually relocates the problematic
+  // code to after NodeDef is fully defined. See the docs on the specialized
+  // trait for details.
+  //
+  // Note: this is only needed by our C++17 implementation of NodeRange (in
+  // ast.h). If we stop supporting C++17, this can be deleted.
   template<>
   struct intrusive_refcounted_traits<NodeDef>
   {

--- a/include/trieste/token.h
+++ b/include/trieste/token.h
@@ -11,18 +11,6 @@
 namespace trieste
 {
   class NodeDef;
-
-  // Because NodeDef is an incomplete type in this file, we need to explicitly
-  // defer trying to express its refcount increment and decrement (or we get
-  // incomplete type error). The two functions that are not implemented here can
-  // be found under NodeDef's definition.
-  template<>
-  struct intrusive_refcounted_traits<NodeDef>
-  {
-    static constexpr void intrusive_inc_ref(NodeDef*);
-    static constexpr void intrusive_dec_ref(NodeDef*);
-  };
-
   using Node = intrusive_ptr<NodeDef>;
 
   struct TokenDef;

--- a/include/trieste/writer.h
+++ b/include/trieste/writer.h
@@ -130,7 +130,7 @@ namespace trieste
 
     static Destination dir(const std::filesystem::path& path)
     {
-      auto d = intrusive_ptr(new DestinationDef());
+      auto d = Destination::make();
       d->mode_ = Mode::FileSystem;
       d->path_ = path;
       return d;
@@ -138,7 +138,7 @@ namespace trieste
 
     static Destination console()
     {
-      auto d = intrusive_ptr(new DestinationDef());
+      auto d = Destination::make();
       d->mode_ = Mode::Console;
       d->path_ = ".";
       return d;
@@ -146,7 +146,7 @@ namespace trieste
 
     static Destination synthetic()
     {
-      auto d = intrusive_ptr(new DestinationDef());
+      auto d = Destination::make();
       d->mode_ = Mode::Synthetic;
       d->path_ = ".";
       return d;

--- a/include/trieste/writer.h
+++ b/include/trieste/writer.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "passes.h"
+#include "trieste/intrusive_ptr.h"
 #include "trieste/wf.h"
 
 #include <filesystem>
@@ -10,9 +11,9 @@
 namespace trieste
 {
   class DestinationDef;
-  using Destination = std::shared_ptr<DestinationDef>;
+  using Destination = intrusive_ptr<DestinationDef>;
 
-  class DestinationDef
+  class DestinationDef : public intrusive_refcounted<DestinationDef>
   {
   private:
     enum class Mode
@@ -129,7 +130,7 @@ namespace trieste
 
     static Destination dir(const std::filesystem::path& path)
     {
-      auto d = std::make_shared<DestinationDef>();
+      auto d = intrusive_ptr(new DestinationDef());
       d->mode_ = Mode::FileSystem;
       d->path_ = path;
       return d;
@@ -137,7 +138,7 @@ namespace trieste
 
     static Destination console()
     {
-      auto d = std::make_shared<DestinationDef>();
+      auto d = intrusive_ptr(new DestinationDef());
       d->mode_ = Mode::Console;
       d->path_ = ".";
       return d;
@@ -145,7 +146,7 @@ namespace trieste
 
     static Destination synthetic()
     {
-      auto d = std::make_shared<DestinationDef>();
+      auto d = intrusive_ptr(new DestinationDef());
       d->mode_ = Mode::Synthetic;
       d->path_ = ".";
       return d;

--- a/parsers/yaml/reader.cc
+++ b/parsers/yaml/reader.cc
@@ -1,11 +1,8 @@
 #include "internal.h"
-#include "trieste/pass.h"
-#include "trieste/rewrite.h"
-#include "trieste/source.h"
-#include "trieste/token.h"
 
 #include <iterator>
 #include <optional>
+#include <trieste/trieste.h>
 
 namespace
 {
@@ -1157,8 +1154,8 @@ namespace
             (T(MaybeDirective)[MaybeDirective] * ~T(NewLine) *
              End)([](auto& n) {
               Node dir = n.front();
-              Node doc = dir->parent()->parent()->shared_from_this();
-              Node stream = doc->parent()->shared_from_this();
+              Node doc = dir->parent()->parent()->intrusive_ptr_from_this();
+              Node stream = doc->parent()->intrusive_ptr_from_this();
               return stream->find(doc) < stream->end() - 1;
             }) >>
           [](Match& _) {
@@ -1866,7 +1863,7 @@ namespace
 
         In(SequenceIndent) * T(Indent, BlockIndent)[Indent]([](auto& n) {
           Node indent = n.front();
-          Node parent = indent->parent()->shared_from_this();
+          Node parent = indent->parent()->intrusive_ptr_from_this();
           return same_indent(parent, indent);
         }) >>
           [](Match& _) -> Node {
@@ -2187,7 +2184,7 @@ namespace
             (T(ValueGroup) << (T(FlowMapping, FlowSequence))[Flow])(
               [](auto& n) {
                 Node group = n.front();
-                Node item = group->parent()->shared_from_this();
+                Node item = group->parent()->intrusive_ptr_from_this();
                 Node flow = group->front();
                 std::size_t item_indent = item->location().linecol().second;
                 std::size_t flow_indent = min_indent(flow);

--- a/parsers/yaml/writer.cc
+++ b/parsers/yaml/writer.cc
@@ -1,10 +1,9 @@
 #include "internal.h"
-#include "trieste/rewrite.h"
-#include "trieste/utf8.h"
-#include "trieste/wf.h"
 #include "yaml.h"
 
 #include <string>
+#include <trieste/trieste.h>
+#include <trieste/utf8.h>
 
 namespace
 {
@@ -116,7 +115,7 @@ namespace
 
     if (current->in({MappingItem, FlowMappingItem}))
     {
-      newline = newline || !is_complex(current->shared_from_this());
+      newline = newline || !is_complex(current->intrusive_ptr_from_this());
     }
 
     return newline && !current->in({Sequence, FlowSequence});

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_libraries(trieste_intrusive_ptr_test trieste::trieste)
 
 # This test might not make so much sense without asan enabled, but might as well
 # check that the test compiles and doesn't crash on other compilers.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT TRIESTE_SANITIZE)
   target_compile_options(trieste_intrusive_ptr_test PUBLIC -g -fsanitize=thread)
   target_link_libraries(trieste_intrusive_ptr_test -fsanitize=thread)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+add_executable(trieste_intrusive_ptr_test
+  intrusive_ptr_test.cc
+)
+target_link_libraries(trieste_intrusive_ptr_test trieste::trieste)
+
+# This test might not make so much sense without asan enabled, but might as well
+# check that the test compiles and doesn't crash on other compilers.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(trieste_intrusive_ptr_test PUBLIC -g -fsanitize=thread)
+  target_link_libraries(trieste_intrusive_ptr_test -fsanitize=thread)
+endif()
+
+add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test)

--- a/test/intrusive_ptr_test.cc
+++ b/test/intrusive_ptr_test.cc
@@ -4,9 +4,7 @@
 #include <thread>
 #include <trieste/intrusive_ptr.h>
 
-struct Dummy
-: public trieste::
-    intrusive_refcounted<Dummy, trieste::intrusive_ptr_threading::async>
+struct Dummy : public trieste::intrusive_refcounted<Dummy>
 {
   size_t tag;
 

--- a/test/intrusive_ptr_test.cc
+++ b/test/intrusive_ptr_test.cc
@@ -64,7 +64,7 @@ struct Test
     ptrs_per_thread.emplace_back();
     for (size_t i = 0; i < ptr_count; ++i)
     {
-      ptrs_per_thread.front().push_back(ptr_t{new Dummy{i}});
+      ptrs_per_thread.front().push_back(ptr_t::make(i));
     }
     while (ptrs_per_thread.size() < thread_behaviors.size())
     {

--- a/test/intrusive_ptr_test.cc
+++ b/test/intrusive_ptr_test.cc
@@ -1,0 +1,167 @@
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <trieste/intrusive_ptr.h>
+
+struct Dummy
+: public trieste::
+    intrusive_refcounted<Dummy, trieste::intrusive_ptr_threading::async>
+{
+  size_t tag;
+
+  Dummy(size_t tag_) : tag{tag_} {}
+};
+
+using ptr_t = trieste::intrusive_ptr<Dummy>;
+using ActionFn = ptr_t(ptr_t);
+
+std::vector<ActionFn*> actions{
+  [](ptr_t ptr) -> ptr_t {
+    if (ptr == nullptr)
+    {
+      std::cout << "Should only be setting to nullptr once per thread!"
+                << std::endl;
+      std::abort();
+    }
+    return nullptr; // dec_ref on this ptr
+  },
+  [](ptr_t ptr) {
+    auto tmp = std::move(ptr);
+    return tmp;
+  },
+  [](ptr_t ptr) {
+    auto tmp = ptr;
+    return ptr;
+  },
+  [](ptr_t ptr) {
+    auto& alias = ptr;
+    alias = ptr;
+    return ptr;
+  },
+};
+
+struct Behavior
+{
+  size_t action_idx;
+  size_t ptr_idx;
+
+  bool operator<(const Behavior& other) const
+  {
+    return std::pair{action_idx, ptr_idx} <
+      std::pair{other.action_idx, other.ptr_idx};
+  }
+};
+
+struct Test
+{
+  size_t ptr_count;
+  std::vector<std::vector<Behavior>> thread_behaviors;
+
+  void run() const
+  {
+    // Each thread gets its own copy of an array of N pointers, where every
+    // thread shares refcounts with every other thread.
+    std::vector<std::vector<ptr_t>> ptrs_per_thread;
+    ptrs_per_thread.emplace_back();
+    for (size_t i = 0; i < ptr_count; ++i)
+    {
+      ptrs_per_thread.front().push_back(ptr_t{new Dummy{i}});
+    }
+    while (ptrs_per_thread.size() < thread_behaviors.size())
+    {
+      ptrs_per_thread.push_back(ptrs_per_thread.back());
+    }
+
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < thread_behaviors.size(); ++i)
+    {
+      threads.emplace_back([&, i]() {
+        for (auto& behavior : thread_behaviors.at(i))
+        {
+          auto& ptr = ptrs_per_thread.at(i).at(behavior.ptr_idx);
+          ptr = actions[behavior.action_idx](ptr);
+        }
+      });
+    }
+
+    for (auto& thread : threads)
+    {
+      thread.join();
+    }
+
+    // Sanity check: every thread should be setting their ptr to nullptr at some
+    // point
+    for (const auto& ptrs : ptrs_per_thread)
+    {
+      for (const auto& ptr : ptrs)
+      {
+        if (ptr != nullptr)
+        {
+          std::cout << "non-null ptr!" << std::endl;
+          std::abort();
+        }
+      }
+    }
+  }
+};
+
+std::vector<Test>
+build_tests(size_t ptr_count, size_t thread_count, size_t permutations)
+{
+  std::vector<Behavior> all_behaviors;
+  for (size_t action_idx = 0; action_idx < actions.size(); ++action_idx)
+  {
+    for (size_t ptr_idx = 0; ptr_idx < ptr_count; ++ptr_idx)
+    {
+      all_behaviors.push_back({
+        action_idx,
+        ptr_idx,
+      });
+    }
+  }
+
+  std::vector<Test> tests = {{ptr_count, {}}};
+  for (size_t i = 0; i < thread_count; ++i)
+  {
+    std::vector<Test> next_tests;
+    for (const auto& test : tests)
+    {
+      // Allow adding some extra permutations if you think you're stuck at the
+      // first few.
+      for (size_t permutation_idx = 0; permutation_idx < permutations;
+           ++permutation_idx)
+      {
+        auto mod_test = test;
+        mod_test.thread_behaviors.push_back(all_behaviors);
+        next_tests.push_back(mod_test);
+
+        // Unconditionally permute the behaviors. We're not looking for total
+        // coverage, just variety.
+        std::next_permutation(all_behaviors.begin(), all_behaviors.end());
+      }
+    }
+    tests = next_tests;
+  }
+  return tests;
+}
+
+// The intention of this test is to do a lot of work to refcounts, while under
+// some kind of thread sanitizer. Changing the tag on Dummy from async to sync
+// should make Clang's thread sanitizer unhappy, for instance, whereas if the
+// tag is async then everything _should_ be fine.
+int main()
+{
+  // Be very careful when increasing these numbers... they can quickly eat up
+  // your memory and time.
+  auto tests = build_tests(3, 6, 4);
+  std::cout << "Found " << tests.size() << " permutations." << std::endl;
+
+  for (auto test : tests)
+  {
+    test.run();
+  }
+
+  std::cout << "Ran " << tests.size() << " permutations." << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This proposed change relates to the ongoing discussion of #115, regarding how Trieste can reduce its impact on binary size.

One thing we identified was the footprint of shared_ptr destructors, which will be included whenever the ubiquitous `Node` goes out of scope. We considered switching to a customized intrusive reference counted pointer implementation, which might be a bit more efficient, and would give us more control over code generation of such a common case in code that uses Trieste.

The resulting pointer implementation, and its non-inline refcount decrement, saves 300KB on the `yamlc` executable, and saved 1.3MB on rego-cpp's main executable, or about 20% of its original size (6.8MB). Keeping the refcount decrement inlineable (but otherwise the same) saves some space still, but less (200KB for `yamlc`).

Notes:
- ~~there is no support for multithreading in this changeset so far. We don't really need it for now, but perhaps best to add it as a compile-time configuration option.~~ not any more
- ~~question: the thread-safe intrusive ptr is disabled right now; what kind of option would make sense for enabling it?~~ answer after discussion: always enable thread-safety. Implemented.
- ~~this is a breaking change wherever a client was aware of aliases like `Node` being `shared_ptr` specifically. One notable example is the `shared_from_this()` method, which has an equivalent in the new version but is renamed. We could simplify the change by keeping the "shared" name, or we could go with a generic name like `ptr_from_this` to be robust against this problem in the future.~~ answer after discussion: current name is ok, change behavior of `->parent()` in other PR