### PR TITLE
Make parent() return a Node

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -324,7 +324,12 @@ namespace trieste
       return location_;
     }
 
-    NodeDef* parent()
+    Node parent()
+    {
+      return parent_ ? parent_->intrusive_ptr_from_this() : nullptr;
+    }
+
+    NodeDef* parent_unsafe()
     {
       return parent_;
     }
@@ -407,7 +412,7 @@ namespace trieste
 
     auto find_first(Token token, NodeIt begin)
     {
-      assert((*begin)->parent() == this);
+      assert((*begin)->parent_unsafe() == this);
       return std::find_if(
         begin, children.end(), [token](auto& n) { return n->type() == token; });
     }

--- a/include/trieste/parse.h
+++ b/include/trieste/parse.h
@@ -140,7 +140,7 @@ namespace trieste
         while (node->parent()->type().in(skip))
         {
           extend();
-          node = node->parent()->intrusive_ptr_from_this();
+          node = node->parent();
         }
 
         extend();
@@ -148,7 +148,7 @@ namespace trieste
 
         if (p == type)
         {
-          node = p->intrusive_ptr_from_this();
+          node = p;
         }
         else
         {
@@ -216,7 +216,7 @@ namespace trieste
         {
           extend();
 
-          node = node->parent()->intrusive_ptr_from_this();
+          node = node->parent();
           return true;
         }
 
@@ -245,7 +245,7 @@ namespace trieste
         {
           node->push_back(make_error(node->location(), "this is unclosed"));
           term();
-          node = node->parent()->intrusive_ptr_from_this();
+          node = node->parent();
           term();
         }
 

--- a/include/trieste/regex.h
+++ b/include/trieste/regex.h
@@ -186,7 +186,7 @@ namespace trieste
         if (!parent)
           return ast;
 
-        ast = parent->intrusive_ptr_from_this();
+        ast = parent;
       }
     }
 

--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -675,7 +675,7 @@ namespace trieste
             if (p->type() == type)
               return match_continuation(it, parent, match);
 
-          p = p->parent();
+          p = p->parent_unsafe();
         }
 
         return false;

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -594,7 +594,7 @@ namespace trieste
 
           for (auto& child : *current)
           {
-            if (child->parent() != current.get())
+            if (child->parent_unsafe() != current.get())
             {
               logging::Error()
                 << child->location().origin_linecol()

--- a/parsers/yaml/reader.cc
+++ b/parsers/yaml/reader.cc
@@ -283,7 +283,7 @@ namespace
       return front->location().linecol().second;
     }
 
-    return indent_of(node->parent());
+    return indent_of(node->parent_unsafe());
   }
 
   Location trim_start(const Location& loc, std::size_t min_indent)
@@ -618,7 +618,7 @@ namespace
       return Top;
     }
 
-    return find_nearest(node->parent(), tokens);
+    return find_nearest(node->parent_unsafe(), tokens);
   }
 
   std::size_t
@@ -2283,7 +2283,8 @@ namespace
              << (~T(Whitespace) * AnchorTag[Anchor] * ~AnchorTag[Tag] * End)) >>
           [](Match& _) {
             Token nearest_group = find_nearest(
-              _(Anchor)->parent(), {DocumentGroup, KeyGroup, ValueGroup});
+              _(Anchor)->parent_unsafe(),
+              {DocumentGroup, KeyGroup, ValueGroup});
             return Lift << nearest_group << _(Anchor) << _(Tag);
           },
 
@@ -2874,7 +2875,7 @@ namespace
        {
          (T(DoubleQuote)[DoubleQuote] << End) >>
            [](Match& _) {
-             std::size_t indent = indent_of(_(DoubleQuote)->parent());
+             std::size_t indent = indent_of(_(DoubleQuote)->parent_unsafe());
              if (_(DoubleQuote)->parent() != Document)
              {
                indent += 1;
@@ -2891,7 +2892,7 @@ namespace
 
          (T(SingleQuote)[SingleQuote] << End) >>
            [](Match& _) {
-             std::size_t indent = indent_of(_(SingleQuote)->parent());
+             std::size_t indent = indent_of(_(SingleQuote)->parent_unsafe());
              if (_(SingleQuote)->parent() != Document)
              {
                indent += 1;
@@ -2913,7 +2914,8 @@ namespace
                   T(ChompIndicator)[ChompIndicator] *
                   T(BlockLine)++[BlockLine] * End)) >>
            [](Match& _) {
-             std::size_t indent = indent_of(_(IndentIndicator)->parent());
+             std::size_t indent =
+               indent_of(_(IndentIndicator)->parent_unsafe());
              std::size_t relative_indent =
                _(IndentIndicator)->location().view()[0] - '0';
              indent += relative_indent;
@@ -2925,7 +2927,8 @@ namespace
               << (T(IndentIndicator)[IndentIndicator] *
                   T(BlockLine)++[BlockLine] * End)) >>
            [](Match& _) {
-             std::size_t indent = indent_of(_(IndentIndicator)->parent());
+             std::size_t indent =
+               indent_of(_(IndentIndicator)->parent_unsafe());
              std::size_t relative_indent =
                _(IndentIndicator)->location().view()[0] - '0';
              indent += relative_indent;

--- a/parsers/yaml/writer.cc
+++ b/parsers/yaml/writer.cc
@@ -84,7 +84,7 @@ namespace
 
   bool is_in(const Node& node, std::set<Token> tokens)
   {
-    NodeDef* parent = node->parent();
+    NodeDef* parent = node->parent_unsafe();
     while (parent != Top)
     {
       if (tokens.count(parent->type()) > 0)
@@ -92,7 +92,7 @@ namespace
         return true;
       }
 
-      parent = parent->parent();
+      parent = parent->parent_unsafe();
     }
 
     return false;
@@ -101,16 +101,16 @@ namespace
   bool is_sequence_out(Node node)
   {
     bool newline = false;
-    NodeDef* current = node->parent();
+    NodeDef* current = node->parent_unsafe();
     if (current->in({AnchorValue, TagValue}))
     {
       newline = true;
-      current = current->parent();
+      current = current->parent_unsafe();
     }
 
     if (current->in({AnchorValue, TagValue}))
     {
-      current = current->parent();
+      current = current->parent_unsafe();
     }
 
     if (current->in({MappingItem, FlowMappingItem}))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,4 +11,4 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT TRIESTE_SANITIZE)
   target_link_libraries(trieste_intrusive_ptr_test -fsanitize=thread)
 endif()
 
-add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_intrusive_ptr_test>)
+add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,4 +11,4 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT TRIESTE_SANITIZE)
   target_link_libraries(trieste_intrusive_ptr_test -fsanitize=thread)
 endif()
 
-add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test)
+add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_intrusive_ptr_test>)


### PR DESCRIPTION
Based on a recent discussion that was left out of scope of #128, there was an idea to make `->parent()` return a `Node` rather than require callers to use `shared_from_this` (or `intrusive_ptr_from_this` now).

This PR makes that change. It:
- changes `parent()` to return `Node`
- adds `parent_unsafe()` that keeps old behavior if you don't want refcounting overheads and you know your borrow is safe

Point of discussion: what do we do with original calls to `parent`? Do all those calls in YAML change type, or do we make them `parent_unsafe`? I'm told it might have performance implications. So far, I only made `->parent()->intrusive_ptr_from_this()` into `->parent()` and otherwise went the unsafe route, but there's plenty of room for "don't care keep it simple" in other cases.

~~There's also a quick fix here for the test cases breaking in dependent projects, since this whole conversation is part of updating rego-cpp's dependencies. If this takes too long I can split that out.~~ Moved to another PR