### PR TITLE
Fix intrusive_ptr test breakage in dependencies

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -21,6 +21,7 @@ jobs:
         include:
         - platform: "ubuntu-latest"
           variant: "ninja"
+          build-type: "Release"
           compiler: "clang"
           cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_BUILD_PARSER_TESTS=1"
           generator: "-G Ninja"

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  global-cmake-flags: -DTRIESTE_ENABLE_TESTING=1
+
 jobs:
   build-test:
     strategy:
@@ -67,7 +70,7 @@ jobs:
       run: ${{matrix.dependencies}}
       
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DTRIESTE_ENABLE_TESTING=1 -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.generator}} ${{matrix.standard}} ${{matrix.cmake-options}}
+      run: cmake -B ${{github.workspace}}/build ${{env.global-cmake-flags}} -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.generator}} ${{matrix.standard}} ${{matrix.cmake-options}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -12,36 +12,38 @@ jobs:
       matrix:
         platform: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         build-type: [ "Release", "Debug" ]
+        cmake-options: [ "" ] # replaced in includes below
         standard: [ "", "-DTRIESTE_USE_CXX17=ON" ]
+        enable-tests: [ "-DTRIESTE_ENABLE_TESTING=1" ]
         compiler: [ "", "clang" ]
         variant: [""]
         
         include:
         - platform: "ubuntu-latest"
           compiler: "clang"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_BUILD_PARSER_TESTS=1"
           generator: "-G Ninja"
           dependencies: "sudo apt install ninja-build"
 
         - platform: "windows-latest"
           variant:  "build-parser-tests"
           build-type: "Release"
-          cmake-options: "-DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
         
         - platform: "macos-latest"
           variant:  "build-parser-tests"
           build-type: "Release"
-          cmake-options: "-DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
 
         - platform: "ubuntu-latest"
           variant: "asan"
           build-type: "Release"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=address -DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=address -DTRIESTE_BUILD_PARSER_TESTS=1"
 
         - platform: "ubuntu-latest"
           variant: "ubsan"
           build-type: "Release"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=undefined -DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=undefined -DTRIESTE_BUILD_PARSER_TESTS=1"
 
         exclude:
         # Mac is already using clang.
@@ -65,7 +67,7 @@ jobs:
       run: ${{ matrix.dependencies }}
       
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.generator}} ${{matrix.standard}} ${{matrix.cmake-options}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.generator}} ${{matrix.standard}} ${{matrix.enable-tests}} ${{matrix.cmake-options}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -22,7 +22,6 @@ jobs:
         - platform: "ubuntu-latest"
           variant: "ninja"
           compiler: "clang"
-          build-type: "Release"
           cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_BUILD_PARSER_TESTS=1"
           generator: "-G Ninja"
           dependencies: "sudo apt install ninja-build"
@@ -58,9 +57,9 @@ jobs:
       # Don't abort runners if a single one fails
       fail-fast: false
 
-    runs-on: ${{matrix.platform}}
+    runs-on: ${{ matrix.platform }}
 
-    name: ${{matrix.platform}} ${{matrix.build-type}} ${{matrix.standard}} ${{matrix.compiler}} ${{matrix.variant}}
+    name: ${{ matrix.platform }} ${{ matrix.build-type }} ${{ matrix.standard }} ${{ matrix.compiler }} ${{ matrix.variant }}
 
     steps:
     - uses: actions/checkout@v3
@@ -69,11 +68,11 @@ jobs:
       run: ${{ matrix.dependencies }}
       
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.generator}} ${{matrix.standard}} ${{matrix.enable-tests}} ${{matrix.cmake-options}}
+      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} ${{ matrix.generator }} ${{ matrix.standard }} ${{ matrix.enable-tests }} ${{ matrix.cmake-options }}
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
+      run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build-type }}
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{matrix.build-type}} --output-on-failure --timeout 400 --interactive-debug-mode 0 
+      working-directory: ${{ github.workspace }}/build
+      run: ctest -C ${{ matrix.build-type }} --output-on-failure --timeout 400 --interactive-debug-mode 0 

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -12,16 +12,14 @@ jobs:
       matrix:
         platform: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         build-type: [ "Release", "Debug" ]
-        cmake-options: [ "" ] # replaced in includes below
+        # Note: cmake-options is missing here on purpose to let it be overridden by includes
         standard: [ "", "-DTRIESTE_USE_CXX17=ON" ]
-        enable-tests: [ "-DTRIESTE_ENABLE_TESTING=1" ]
         compiler: [ "", "clang" ]
         variant: [""]
         
         include:
+        # ensures ubuntu-latest clang uses Ninja (modifies the matrix entry)
         - platform: "ubuntu-latest"
-          variant: "ninja"
-          build-type: "Release"
           compiler: "clang"
           cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_BUILD_PARSER_TESTS=1"
           generator: "-G Ninja"
@@ -58,22 +56,22 @@ jobs:
       # Don't abort runners if a single one fails
       fail-fast: false
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{matrix.platform}}
 
-    name: ${{ matrix.platform }} ${{ matrix.build-type }} ${{ matrix.standard }} ${{ matrix.compiler }} ${{ matrix.variant }}
+    name: ${{matrix.platform}} ${{matrix.build-type}} ${{matrix.standard}} ${{matrix.compiler}} ${{matrix.variant}}
 
     steps:
     - uses: actions/checkout@v3
     
     - name: Install build dependencies
-      run: ${{ matrix.dependencies }}
+      run: ${{matrix.dependencies}}
       
     - name: Configure CMake
-      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} ${{ matrix.generator }} ${{ matrix.standard }} ${{ matrix.enable-tests }} ${{ matrix.cmake-options }}
+      run: cmake -B ${{github.workspace}}/build -DTRIESTE_ENABLE_TESTING=1 -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.generator}} ${{matrix.standard}} ${{matrix.cmake-options}}
 
     - name: Build
-      run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build-type }}
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
 
     - name: Test
-      working-directory: ${{ github.workspace }}/build
-      run: ctest -C ${{ matrix.build-type }} --output-on-failure --timeout 400 --interactive-debug-mode 0 
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build-type}} --output-on-failure --timeout 400 --interactive-debug-mode 0 

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -19,29 +19,29 @@ jobs:
         include:
         - platform: "ubuntu-latest"
           compiler: "clang"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
           generator: "-G Ninja"
           dependencies: "sudo apt install ninja-build"
 
         - platform: "windows-latest"
           variant:  "build-parser-tests"
           build-type: "Release"
-          cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
         
         - platform: "macos-latest"
           variant:  "build-parser-tests"
           build-type: "Release"
-          cmake-options: "-DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
 
         - platform: "ubuntu-latest"
           variant: "asan"
           build-type: "Release"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=address -DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=address -DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
 
         - platform: "ubuntu-latest"
           variant: "ubsan"
           build-type: "Release"
-          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=undefined -DTRIESTE_BUILD_PARSER_TESTS=1"
+          cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_SANITIZE=undefined -DTRIESTE_ENABLE_TESTING=1 -DTRIESTE_BUILD_PARSER_TESTS=1"
 
         exclude:
         # Mac is already using clang.

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -20,7 +20,9 @@ jobs:
         
         include:
         - platform: "ubuntu-latest"
+          variant: "ninja"
           compiler: "clang"
+          build-type: "Release"
           cmake-options: "-DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15 -DTRIESTE_BUILD_PARSER_TESTS=1"
           generator: "-G Ninja"
           dependencies: "sudo apt install ninja-build"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(trieste VERSION 1.0.0 LANGUAGES CXX)
 
 # #############################################
 # Options
+option(TRIESTE_ENABLE_TESTING "Specifies whether to enable Trieste's tests" OFF)
 option(TRIESTE_BUILD_SAMPLES "Specifies whether to build the samples" ON)
 option(TRIESTE_BUILD_PARSERS "Specifies whether to build the parsers" ON)
 option(TRIESTE_BUILD_PARSER_TESTS "Specifies whether to build the parser tests" OFF)
@@ -175,12 +176,15 @@ export(PACKAGE trieste)
 
 # #############################################
 # # Add core Trieste tests
-enable_testing()
-add_subdirectory(test)
+if(TRIESTE_ENABLE_TESTING)
+  enable_testing()
+  add_subdirectory(test)
+endif()
 
 # #############################################
 # # Add samples
 if(TRIESTE_BUILD_SAMPLES)
+  enable_testing()
   add_subdirectory(samples/infix)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,4 +11,4 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT TRIESTE_SANITIZE)
   target_link_libraries(trieste_intrusive_ptr_test -fsanitize=thread)
 endif()
 
-add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test)
+add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_intrusive_ptr_test>)


### PR DESCRIPTION
Does what the title says.

I noticed when trying to update rego-cpp that the tests, when auto-run from a dependency, fail because they can't find their executables.

This didn't show up before because Trieste did not itself have tests until I added this last set (all tests were indirect and optional, part of the tools).

It might actually be more reasonable to disable running tests when included as a dependency, but I'm not sure how to do that. Looking around on the internet, with my search terms at least, is inconclusive.

This change on its own at least makes sure the tests can be launched correctly regardless of context.