### PR TITLE
Fixing some YAML corner cases

### DIFF
--- a/parsers/yaml/parse.cc
+++ b/parsers/yaml/parse.cc
@@ -559,6 +559,11 @@ namespace trieste
               m.add(SingleQuote);
             },
 
+          R"("[^"]*\n\-\-\-[^"]*")" >>
+            [](auto& m) {
+              m.error("Invalid document marker in double quoted scalar");
+            },
+
           // Double-quote. NB this captures absolutely everything at this stage,
           // and is cleaned up in the quotes() pass, because the semantics of
           // quoted strings are too complex to handle in this parser.


### PR DESCRIPTION
- The error for the document start marker `---` in a double quoted string was stricter than needed. This has been loosened to allow for a wider range of strings
- Comments after the document start marker before a mapping were causing issues with the whitespace logic. This has been resolved.
- Fixed an issue with comments within complex key constructions in flow mappings
- Fixed an issue with trailing comments in flow sequences