### PR TITLE
Support for Reapply effect

### DIFF
--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -26,6 +26,9 @@ namespace trieste
     using F = std::function<size_t(Node)>;
 
   private:
+    const ptrdiff_t NOCHANGE = -1;
+    const ptrdiff_t REAPPLY = -2;
+
     std::string name_;
     const wf::Wellformed& wf_ = wf::empty;
     dir::flag direction_;
@@ -239,7 +242,7 @@ namespace trieste
       NodeIt& it,
       const Node& node)
     {
-      ptrdiff_t replaced = -1;
+      ptrdiff_t replaced = NOCHANGE;
       // Replace [start, it) with whatever the rule builds.
       auto replace = rule_replace(match);
 
@@ -258,14 +261,14 @@ namespace trieste
       {
         replaced = 0;
       }
-      else if (replace == Seq)
+      else if (replace == Seq || replace == Reapply)
       {
         // Unpack the sequence.
         std::for_each(replace->begin(), replace->end(), [&](Node n) {
           n->set_location(loc);
         });
 
-        replaced = replace->size();
+        replaced = replace == Reapply? REAPPLY: replace->size();
         it = node->insert(it, replace->begin(), replace->end());
       }
       else
@@ -293,7 +296,7 @@ namespace trieste
       // Perform matching at this level
       while (it != node->end())
       {
-        ptrdiff_t replaced = -1;
+        ptrdiff_t replaced = NOCHANGE;
 
         auto start = it;
         // Find rule set for this parent and start token combination.
@@ -306,7 +309,7 @@ namespace trieste
             SNMALLOC_LIKELY(!range_contains_error(start, it)))
           {
             replaced = replace(match, rule.second, start, it, node);
-            if (replaced != -1)
+            if (replaced != NOCHANGE)
             {
               changes += replaced;
               break;
@@ -315,10 +318,14 @@ namespace trieste
           it = start;
         }
 
-        if (replaced == -1)
+        if (replaced == NOCHANGE)
         {
           // If we didn't do anything, advance to the next node.
           ++it;
+        }
+        else if (replaced == REAPPLY)
+        {
+          // Don't advance so that we match on the inserted nodes next
         }
         else if (flag(dir::once))
         {

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -26,8 +26,7 @@ namespace trieste
     using F = std::function<size_t(Node)>;
 
   private:
-    const ptrdiff_t NOCHANGE = -1;
-    const ptrdiff_t REAPPLY = -2;
+    enum : ptrdiff_t {NOCHANGE = -1, REAPPLY = -2};
 
     std::string name_;
     const wf::Wellformed& wf_ = wf::empty;

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -26,7 +26,8 @@ namespace trieste
     using F = std::function<size_t(Node)>;
 
   private:
-    enum : ptrdiff_t {NOCHANGE = -1, REAPPLY = -2};
+    static const int NOCHANGE = -1;
+    static const int REAPPLY = -2;
 
     std::string name_;
     const wf::Wellformed& wf_ = wf::empty;

--- a/include/trieste/token.h
+++ b/include/trieste/token.h
@@ -174,19 +174,19 @@ namespace trieste
   inline const auto Group = TokenDef("group");
 
   // Special tokens for effects
-  inline const auto Seq = TokenDef("seq");
+  inline const auto Seq = TokenDef("seq", flag::internal);
   inline const auto Lift = TokenDef("lift", flag::internal);
-  inline const auto NoChange = TokenDef("nochange");
+  inline const auto NoChange = TokenDef("nochange", flag::internal);
   inline const auto Reapply = TokenDef("reapply", flag::internal);
 
   // Special tokens for symbol tables
-  inline const auto Include = TokenDef("include");
+  inline const auto Include = TokenDef("include", flag::internal);
 
   // Special tokens for error handling
-  inline const auto Invalid = TokenDef("invalid");
+  inline const auto Invalid = TokenDef("invalid", flag::internal);
   inline const auto Error = TokenDef("error", flag::internal);
-  inline const auto ErrorMsg = TokenDef("errormsg", flag::print);
-  inline const auto ErrorAst = TokenDef("errorast");
+  inline const auto ErrorMsg = TokenDef("errormsg", flag::print | flag::internal);
+  inline const auto ErrorAst = TokenDef("errorast", flag::internal);
 
   namespace detail
   {

--- a/include/trieste/token.h
+++ b/include/trieste/token.h
@@ -167,15 +167,23 @@ namespace trieste
     constexpr TokenDef::flag internal = 1 << 6;
   }
 
-  inline const auto Invalid = TokenDef("invalid");
+  // Built-in grouping
   inline const auto Top = TokenDef("top", flag::symtab);
-  inline const auto Group = TokenDef("group");
-  inline const auto File = TokenDef("file");
   inline const auto Directory = TokenDef("directory");
+  inline const auto File = TokenDef("file");
+  inline const auto Group = TokenDef("group");
+
+  // Special tokens for effects
   inline const auto Seq = TokenDef("seq");
   inline const auto Lift = TokenDef("lift", flag::internal);
   inline const auto NoChange = TokenDef("nochange");
+  inline const auto Reapply = TokenDef("reapply", flag::internal);
+
+  // Special tokens for symbol tables
   inline const auto Include = TokenDef("include");
+
+  // Special tokens for error handling
+  inline const auto Invalid = TokenDef("invalid");
   inline const auto Error = TokenDef("error", flag::internal);
   inline const auto ErrorMsg = TokenDef("errormsg", flag::print);
   inline const auto ErrorAst = TokenDef("errorast");


### PR DESCRIPTION
This PR adds an effect `Reapply` that makes matching continue at the newly inserted node(s). It is intended to be used in `once` passes for "local fixpoint" computations but can be used with non-`once` passes as well. `Reapply` works like `Seq` in that the node is replaced by all of its children. As an example, consider the rewrite rules

    T(A) * T(A) >> [](auto&) -> Node { return B; }
    T(B) * T(A) >> [](auto&) -> Node { return C; }

When run in a `once` pass they would turn "**A A** A" into "B A". Changing the effect in the first rule to `return Reapply << B` would make the rewrites in sequence be "**A A** A ~> **B A** ~> C". Of course, careless use of `Reapply` can make a `once` pass loop forever.

Closes #139.