### PR TITLE
Remove target from shrubbery sample's CMake file

### DIFF
--- a/samples/shrubbery/CMakeLists.txt
+++ b/samples/shrubbery/CMakeLists.txt
@@ -11,4 +11,3 @@ target_link_libraries(shrubbery
 add_test(NAME shrubbery COMMAND shrubbery test -f)
 
 install(TARGETS shrubbery RUNTIME DESTINATION shrubbery)
-install(DIRECTORY examples DESTINATION shrubbery)


### PR DESCRIPTION
Removes a line from `CMakeLists.txt` in the shrubbery sample that was left there by accident.