### PR TITLE
Add support for removing shapes from WF specifications

### DIFF
--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -1071,6 +1071,30 @@ namespace trieste
         wf.append(shape2);
         return wf;
       }
+
+      inline Wellformed operator-(const Wellformed& wf, const Token& token) {
+        Wellformed wf2;
+        wf2.shapes.insert(wf.shapes.begin(), wf.shapes.end());
+        wf2.shapes.erase(token);
+        return wf2;
+      }
+
+      inline Wellformed operator-(const Wellformed& wf, Token&& token) {
+        Wellformed wf2;
+        wf2.shapes.insert(wf.shapes.begin(), wf.shapes.end());
+        wf2.shapes.erase(token);
+        return wf2;
+      }
+
+      inline Wellformed operator-(Wellformed&& wf, const Token& token) {
+        wf.shapes.erase(token);
+        return std::move(wf);
+      }
+
+      inline Wellformed operator-(Wellformed&& wf, Token&& token) {
+        wf.shapes.erase(token);
+        return std::move(wf);
+      }
     }
 
     namespace detail


### PR DESCRIPTION
This PR adds support for removing shapes from a WF specification:

```
inline const auto wf1 =
  (Foo <<= Bar++)
| Baz <<= Foo * Bar
;

inline const auto wf2 =
  (wf1 - Foo)
  | Bar <<= Baz++
```

In `wf2` `Foo`s can still appear in the tree, but they must have zero children (just like if they were never in the WF to begin with). Without this PR, the only way to achieve the same functionality is by repeating the shape list without `Foo`.

To be honest, I'm not sure what I'm doing with the functions taking rvalues, I'm just parroting other similar functions.