### PR TITLE
Fuzzer started from second instead of first pass as default when using Driver

### DIFF
--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -177,7 +177,7 @@ namespace trieste
 
         if (test_start_pass.empty())
         {
-          test_start_pass = pass_names.at(1);
+          test_start_pass = pass_names.at(0);
           test_end_pass = pass_names.back();
         }
         else if (test_end_pass.empty())


### PR DESCRIPTION
In the ```run()``` method in ```driver.h```, the "```test_start_pass"``` for fuzzing was previously selected as ```test_start_pass = pass_names.at(1);``` which gives the second pass after the parser but compensates for the initial pass being the pass at  ```start_index - 1``` in the method ```test()``` in the ```Fuzzer``` class.

However, the start_index for the returned ```Fuzzer``` object returned from ```reader.pass_index()``` compensates in the other direction and adds +1 to the pass index, meaning the first pass in the pass sequence in the reader does not get tested if not given explicitly.
```
  return Fuzzer(reader)
           ...
          .start_index(reader.pass_index(test_start_pass))
          ...
          .test();
```

I just added the minimal fix to start fuzz testing from the first pass as default, but perhaps the logic in ```pass_index``` and ```test()``` could also be changed. 