### PR TITLE
Added upper bounds for sequences

### DIFF
--- a/parsers/json/internal.h
+++ b/parsers/json/internal.h
@@ -19,7 +19,7 @@ namespace trieste
     // clang-format off
     inline const auto wf_parse =
       (Top <<= File)
-      | (File <<= Group++)
+      | (File <<= ~Group)
       | (Value <<= Group)
       | (Array <<= Group)
       | (Object <<= Group)


### PR DESCRIPTION
This PR adds support for giving upper bounds for sequences in the well-formedness specifications:
```
inline const auto some_wf =
  (File <<= Group++) // Zero or more groups
| (Foo <<= Group++[1]) // One or more groups
| (Bar <<= Group++[1][3] // Between one and three groups
```

One motivating use case is having a top-level optional shape (which is shorthand for `++[0][1]`):
```
inline const auto foo_wf =
  some_wf
  | (Paren <<= ~(Foo | Bar)) // Optionally contains a single Foo or a single Bar
```
Before this, the closest you could get was using `++`, which would mess with fuzz testing. Just as sequences, optional shapes can only be used at the top level of a shape; you still cannot write e.g. `Paren <<= Foo * ~Bar` or `Paren <<= Foo * Bar++`.

The JSON parser had `File <<= Group++` even though the initial parse pass can produce at most one group, but I did not find any more interesting usages of this pattern in any other sample or parser. Manual toying around with this seems to suggest that both checking and generation handles the new shape correctly.