### PR TITLE
Updated parser API with convenience in and blind pop

### DIFF
--- a/include/trieste/parse.h
+++ b/include/trieste/parse.h
@@ -84,12 +84,25 @@ namespace trieste
         return node == type;
       }
 
+      bool in(const std::initializer_list<Token>& types) const
+      {
+        return node->type().in(types);
+      }
+
       bool group_in(const Token& type) const
       {
         if (!in(Group))
           return false;
 
         return node->parent() == type;
+      }
+
+      bool group_in(const std::initializer_list<Token>& types) const
+      {
+        if (!in(Group))
+          return false;
+
+        return node->parent()->type().in(types);
       }
 
       bool previous(const Token& type) const
@@ -164,6 +177,17 @@ namespace trieste
       {
         add(type, index);
         node = node->back();
+      }
+
+      Token pop()
+      {
+        if (in(Top))
+          throw std::runtime_error("cannot pop top node");
+
+        auto type = node->type();
+        pop(type);
+
+        return type;
       }
 
       void pop(const Token& type)

--- a/samples/shrubbery/parse.cc
+++ b/samples/shrubbery/parse.cc
@@ -163,23 +163,16 @@ namespace shrubbery
 
     // Terminate a given set of Tokens
     auto close_all = [pop_indentation, expect_indent, indent](auto& m, std::initializer_list<Token> tokens) {
-      bool progress = true;
-      while (progress) {
-        progress = false;
-        for (auto& token : tokens) {
-          if (m.in(token) || m.group_in(token)) {
-            m.term({token});
-            progress = true;
-            // Blocks and alternatives will have established new indentation
-            // levels (unless they were just opened), so these need to be popped
-            if (!indent->empty() && !*expect_indent && (token == Block || token == Alt)) {
-                pop_indentation();
-            } else if (*expect_indent) {
-                *expect_indent = false;
-            }
-            break;
+      while (m.in(tokens) || m.group_in(tokens)) {
+          m.term();
+          auto token = m.pop();
+          // Blocks and alternatives will have established new indentation
+          // levels (unless they were just opened), so these need to be popped
+          if (!indent->empty() && !*expect_indent && (token == Block || token == Alt)) {
+            pop_indentation();
+          } else if (*expect_indent) {
+            *expect_indent = false;
           }
-        }
       }
       *expect_indent = false;
     };


### PR DESCRIPTION
This PR adds two things to the parser API:

* Versions of `in` and `group_in` that takes a list of tokens, for checking if we are in one of several kinds of nodes.
* A version of `pop` that takes no argument, blindly popping from whatever node we are in and returning its token.

I find myself often wanting to implement "keep popping until we are no longer in one of these things" or "keep popping until we are inside one of these things". This makes that kind of logic simpler to implement (see diff of shrubbery parser for an example).