### PR TITLE
Check indexing when binding symbols

### DIFF
--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -469,6 +469,11 @@ namespace trieste
         {
           if (field.name == binding)
           {
+            if (index >= node->size())
+              // Node does not have enough children. Pretend all is fine to
+              // allow error nodes, otherwise WF check will sort it out.
+              return true;
+
             auto name = node->at(index)->location();
 
             if (!node->bind(name))


### PR DESCRIPTION
This PR fixes #140. You could get an out-of-bounds error when populating symbol tables if you generated a node with a binding (e.g. `(Assign <<= Ident * Expr)[Ident])`) with too few children. The solution here is to abort early and pretend that everything is fine. This allows checking for errors (maybe the binding was malformed due to the presence of errors) and relies on the WF check to reject the tree later. You cannot simply do the WF check first since that also checks that bindings have a corresponding entry in a symbol table.