### PR TITLE
Adding conditional passes

### DIFF
--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -24,6 +24,7 @@ namespace trieste
   {
   public:
     using F = std::function<size_t(Node)>;
+    using CondF = std::function<bool(Node)>;
 
   private:
     static const int NOCHANGE = -1;
@@ -40,6 +41,7 @@ namespace trieste
 
     F pre_once;
     F post_once;
+    CondF cond_run;
     std::map<Token, F> pre_;
     std::map<Token, F> post_;
 
@@ -115,6 +117,11 @@ namespace trieste
       post_once = f;
     }
 
+    void cond(CondF f)
+    {
+      cond_run = f;
+    }
+
     void pre(const Token& type, F f)
     {
       pre_[type] = f;
@@ -160,6 +167,12 @@ namespace trieste
       size_t changes_sum = 0;
       size_t count = 0;
 
+      if (cond_run && !cond_run(node))
+      {
+        logging::Debug()
+          << "Pass was not executed due to cond function returning false.";
+        return {node, count, changes_sum};
+      }
       if (pre_once)
         changes_sum += pre_once(node);
 

--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -117,9 +117,10 @@ namespace trieste
       post_once = f;
     }
 
-    void cond(CondF f)
+    PassDef cond(CondF f)
     {
       cond_run = f;
+      return *this;
     }
 
     void pre(const Token& type, F f)
@@ -169,8 +170,7 @@ namespace trieste
 
       if (cond_run && !cond_run(node))
       {
-        logging::Debug()
-          << "Pass was not executed due to cond function returning false.";
+        logging::Debug() << "Pass skipped: cond() returned false.";
         return {node, count, changes_sum};
       }
       if (pre_once)


### PR DESCRIPTION
This PR introduces the ability to specify a `cond()` function on a pass. The goal is to allow a clear way to disable passes when needed. It's defined similar to the `pre()` and `post()` functions, with the difference that the lambda passed to the function, should return a boolean deciding if the pass should execute.

The `cond()` function can be defined inside a pass similar to the `pre()` and `post()` functions. It  may also be defined in a rewriter, which enables code shown below:

```cpp
Rewriter rewriter = {
  "optimization_analysis",
  {
      gather_instructions(control_flow),
      gather_flow_graph(control_flow),
      constant_folding(control_flow),

      gather_instructions(control_flow).cond(control_is_dirty),
      gather_flow_graph(control_flow).cond(control_is_dirty),
      dead_code_elimination(control_flow),
      dead_code_cleanup(),
  },
  whilelang::normalization_wf,
};
```
The context is that the `gather_instructions` and `gather_flow_graph` passes should not collect control flow information again unless its outdated. 