### PR TITLE
Do not export warning flags, but apply them to all targets the project builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,12 +116,14 @@ if (TRIESTE_SANITIZE)
   target_link_libraries(trieste INTERFACE -fsanitize=${TRIESTE_SANITIZE})
 endif()
 
-if(MSVC)
-  target_compile_options(trieste INTERFACE /W4 /WX /wd5030 /bigobj)
-else()
-  target_compile_options(trieste INTERFACE
-    -Wall -Wextra -Wpedantic -Werror -Wshadow)
-endif()
+function(enable_warnings target)
+  if(MSVC)
+    target_compile_options(${target} PRIVATE /W4 /WX /wd5030 /bigobj)
+  else()
+    target_compile_options(${target} PRIVATE
+      -Wall -Wextra -Wpedantic -Werror -Wshadow)
+  endif()
+endfunction()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(trieste INTERFACE -Wmismatched-tags -fstandalone-debug)

--- a/parsers/json/CMakeLists.txt
+++ b/parsers/json/CMakeLists.txt
@@ -9,6 +9,7 @@ if( BUILD_SHARED_LIBS )
 else()
   add_library(json STATIC ${SOURCES})
 endif()
+enable_warnings(json)
 
 add_library(trieste::json ALIAS json)
 

--- a/parsers/test/CMakeLists.txt
+++ b/parsers/test/CMakeLists.txt
@@ -1,12 +1,14 @@
 ## JSON
 
 add_executable(json_fuzzer json_fuzzer.cc)
+enable_warnings(json_fuzzer)
 
 target_link_libraries(json_fuzzer
   PRIVATE
   trieste::json)
 
 add_executable(json_test json_test.cc)
+enable_warnings(json_test)
 
 target_link_libraries(json_test
   PRIVATE
@@ -23,12 +25,14 @@ install(TARGETS json_fuzzer json_test RUNTIME DESTINATION parsers)
 ## YAML
 
 add_executable(yaml_fuzzer yaml_fuzzer.cc)
+enable_warnings(yaml_fuzzer)
 
 target_link_libraries(yaml_fuzzer
   PRIVATE
   trieste::yaml)
 
 add_executable(yaml_test yaml_test.cc)
+enable_warnings(yaml_test)
 
 target_link_libraries(yaml_test
   PRIVATE

--- a/parsers/yaml/CMakeLists.txt
+++ b/parsers/yaml/CMakeLists.txt
@@ -11,6 +11,7 @@ if( BUILD_SHARED_LIBS )
 else()
   add_library(yaml STATIC ${SOURCES})
 endif()
+enable_warnings(yaml)
 
 add_library(trieste::yaml ALIAS yaml)
 
@@ -53,6 +54,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../include/trieste/yaml.h DESTINATION 
 
 if( TRIESTE_BUILD_PARSER_TOOLS )
   add_executable(yamlc yamlc.cc)
+  enable_warnings(yamlc)
 
   target_link_libraries(yamlc
     PRIVATE

--- a/samples/infix/CMakeLists.txt
+++ b/samples/infix/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(infix_trieste
   infix_trieste.cc
   parse.cc
   )
+enable_warnings(infix_trieste)
 
 target_link_libraries(infix_trieste
   trieste::trieste
@@ -18,6 +19,7 @@ add_executable(infix
   infix.cc
   parse.cc
 )
+enable_warnings(infix)
 
 target_link_libraries(infix
   trieste::trieste

--- a/samples/shrubbery/CMakeLists.txt
+++ b/samples/shrubbery/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(shrubbery
   parse.cc
   shrubbery.cc
   )
+enable_warnings(shrubbery)
 
 target_link_libraries(shrubbery
   trieste::trieste

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(trieste_intrusive_ptr_test
   intrusive_ptr_test.cc
 )
+enable_warnings(trieste_intrusive_ptr_test)
 target_link_libraries(trieste_intrusive_ptr_test trieste::trieste)
 
 # This test might not make so much sense without asan enabled, but might as well
@@ -16,6 +17,7 @@ add_test(NAME trieste_intrusive_ptr_test COMMAND trieste_intrusive_ptr_test WORK
 add_executable(trieste_source_test
   source_test.cc
 )
+enable_warnings(trieste_source_test)
 target_link_libraries(trieste_source_test trieste::trieste)
 
 add_test(NAME trieste_source_test COMMAND trieste_source_test --depth 6 WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_source_test>)


### PR DESCRIPTION
Instead of setting Warnings/Werror on the trieste interface target, which means that any code using the target picks up the flags, this PR is restricting it to the binaries built by the project (tests and sample parser libraries).

This is so that projects that use Trieste, directly and otherwise, as well as other code that is not necessarily warning-free, and that those other projects may not control, can build binaries effectively.

I have diffed the output of `ninja -j1 -v`, pre and post change, to make sure I did not miss anything. Note that projects depending on Trieste, such as https://github.com/microsoft/rego-cpp/ will need to do something similar, to keep building their tests/binaries with Warnings/Werror.