### PR TITLE
Drop requirement that language names match in parsed Trieste files

### DIFF
--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -66,6 +66,10 @@ namespace trieste
       std::filesystem::path output;
       build->add_option("-o,--output", output, "Output path.");
 
+      std::string language_name = reader.language_name();
+      build->add_option(
+        "-n,--language_name", language_name, "Language name to use for the output file.");
+
       std::filesystem::path dump_passes;
       build->add_option(
         "--dump_passes", dump_passes, "Dump passes to the supplied directory.");
@@ -133,6 +137,7 @@ namespace trieste
       {
         reader.executable(argv[0])
           .file(path)
+          .language_name(language_name)
           .debug_enabled(!dump_passes.empty())
           .debug_path(dump_passes)
           .wf_check_enabled(wfcheck)

--- a/include/trieste/reader.h
+++ b/include/trieste/reader.h
@@ -170,6 +170,12 @@ namespace trieste
       return *this;
     }
 
+    Reader& language_name(const std::string& name)
+    {
+      language_name_ = name;
+      return *this;
+    }
+
     const std::string& language_name() const
     {
       return language_name_;


### PR DESCRIPTION
Parsing a Trieste file used to fail if the language names did not match. This PR insteads logs a debug message if this is the case, but does not require it. The use case for this is targeting an external Trieste tool like vbcc. There is also some overdue formatting fixes.