### PR TITLE
Continuation not allowed after `End`

### DIFF
--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -337,7 +337,7 @@ namespace trieste
 
       virtual PatternPtr clone() const& = 0;
 
-      void set_continuation(PatternPtr next)
+      virtual void set_continuation(PatternPtr next)
       {
         if (!continuation)
         {
@@ -752,9 +752,13 @@ namespace trieste
         throw std::runtime_error("Rep(Last) not allowed! (End)++");
       }
 
+      virtual void set_continuation(PatternPtr) override
+      {
+        throw std::runtime_error("Continuation not allowed after `End`");
+      }
+
       bool match(NodeIt& it, const Node& parent, Match&) const& override
       {
-        assert(no_continuation());
         return it == parent->end();
       }
     };


### PR DESCRIPTION
The code checked that it didn't match End and then ignore a continuation. This change makes it so that setting a continuation after End throws an error when the pass is constructed. Previously, it presented the error only when the pattern was matched.