### PR TITLE
Enabling synthetic sources to have an origin

### DIFF
--- a/include/trieste/source.h
+++ b/include/trieste/source.h
@@ -50,10 +50,11 @@ namespace trieste
       return source;
     }
 
-    static Source synthetic(const std::string& contents)
+    static Source synthetic(const std::string& contents, const std::string& origin="")
     {
       auto source = Source::make();
       source->contents = contents;
+      source->origin_ = origin;
       source->find_lines();
       return source;
     }


### PR DESCRIPTION
This simple change allows synthetic sources to have a non-empty value for origin. This allows the creation of fully synthetic "files", *e.g.*, which have been read from an archive.