### PR TITLE
Expose includes defined in a particular scope

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -501,6 +501,15 @@ namespace trieste
       return {};
     }
 
+    const Nodes& includes()
+    {
+      static Nodes empty_includes;
+      if (!symtab_)
+        return empty_includes;
+
+      return symtab_->includes;
+    }
+
     template<typename F>
     Nodes& get_symbols(Nodes& result, F&& f)
     {


### PR DESCRIPTION
This PR allows the includes for a particular scope to be returned.  This enables the includes system to be used for systems of lookup and lookdown that are more complex.  For instance, if the resolution of an various names are required before an include can be followed.  This means that a fixed point graph is required using a system such as `NodeWorker`, and doesn't fit with the simpler builtin notion of lookup. 