### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   global-cmake-flags: -DTRIESTE_ENABLE_TESTING=1
 


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/Trieste/security/code-scanning/2](https://github.com/microsoft/Trieste/security/code-scanning/2)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or per job so that the GITHUB_TOKEN is restricted to only what the workflow requires. For a pure build-and-test workflow that only checks out code and does not write to the repo or manage issues/PRs, `contents: read` is sufficient.

The best fix here is to add a `permissions` block at the top level of the workflow (right under `name:` or `on:`), applying to all jobs. Since the jobs only run `actions/checkout` and local build/test commands, we can safely set `permissions: contents: read`. This documents the workflow’s needs and ensures that even if organization or repository defaults are more permissive, this workflow will only receive read access to repository contents. No other changes are needed, and no existing behavior will be altered.

Concretely: in `.github/workflows/buildtest.yml`, add:

```yaml
permissions:
  contents: read
```

near the top of the file, aligned at the same indentation level as `on:` and `env:`. No imports or other definitions are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
