### PR TITLE
Differential testing

### DIFF
--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -706,6 +706,60 @@ namespace trieste
           [](auto& a, auto& b) { return a->equals(b); }));
     }
 
+    std::pair<Node, Node> diff(Node& other)
+    {
+      std::pair<Node, Node> result = {{}, {}};
+
+      // Each entry holds the remaining unvisited counterpart children at one
+      // level of the tree, stored in reverse so pop_back() is O(1).
+      std::vector<Nodes> level_stack;
+      level_stack.push_back({other});
+
+      traverse(
+        [&](Node& node) -> bool {
+          if (result.first || result.second)
+            return false;
+
+          auto& current_level = level_stack.back();
+          if (current_level.empty())
+          {
+            result = {node, {}};
+            return false;
+          }
+
+          Node cp = current_level.back();
+          current_level.pop_back();
+
+          if (node->type() != cp->type())
+          {
+            result = {node, cp};
+            return false;
+          }
+
+          if ((node->type() & flag::print) && (node->location() != cp->location()))
+          {
+            result = {node, cp};
+            return false;
+          }
+
+          // Push cp's children in reverse order onto a new level.
+          Nodes child_level;
+          child_level.reserve(cp->size());
+          for (auto it = cp->rbegin(); it != cp->rend(); ++it)
+            child_level.push_back(*it);
+          level_stack.push_back(std::move(child_level));
+          return true;
+        },
+        [&](Node&) {
+          auto& child_level = level_stack.back();
+          if (!result.first && !result.second && !child_level.empty())
+            result = {{}, child_level.back()};
+          level_stack.pop_back();
+        });
+
+      return result;
+    }
+
     Node common_parent(Node node)
     {
       return common_parent(node.get());

--- a/include/trieste/ast.h
+++ b/include/trieste/ast.h
@@ -736,7 +736,9 @@ namespace trieste
             return false;
           }
 
-          if ((node->type() & flag::print) && (node->location() != cp->location()))
+          if (
+            (node->type() & flag::print) &&
+            (node->location() != cp->location()))
           {
             result = {node, cp};
             return false;

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -308,21 +308,20 @@ namespace trieste
             test_end_pass = test_start_pass;
         }
 
-        Fuzzer fuzzer =
-          Fuzzer(reader)
-            .max_retries(max_retries)
-            .max_depth(test_max_depth)
-            .failfast(test_failfast)
-            .seed_count(test_seed_count)
-            .start_index(reader.pass_index(test_start_pass))
-            .end_index(reader.pass_index(test_end_pass))
-            .start_seed(test_seed)
-            .bound_vars(bound_vars)
-            .test_sequence(test_sequence)
-            .size_stats(test_size_stats)
-            .test_diff(!path_to_oracle.empty())
-            .oracle_command(oracle_command)
-            .run_as_oracle(oracle);
+        Fuzzer fuzzer = Fuzzer(reader)
+                          .max_retries(max_retries)
+                          .max_depth(test_max_depth)
+                          .failfast(test_failfast)
+                          .seed_count(test_seed_count)
+                          .start_index(reader.pass_index(test_start_pass))
+                          .end_index(reader.pass_index(test_end_pass))
+                          .start_seed(test_seed)
+                          .bound_vars(bound_vars)
+                          .test_sequence(test_sequence)
+                          .size_stats(test_size_stats)
+                          .test_diff(!path_to_oracle.empty())
+                          .oracle_command(oracle_command)
+                          .run_as_oracle(oracle);
 
         if (*entropy)
         {

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -148,6 +148,10 @@ namespace trieste
       test->add_option(
         "--gen_bound", bound_vars, "Generate bound variable names if possible");
 
+      auto oracle = false;
+      test->add_flag(
+        "--oracle", oracle, "Act as an oracle for differential testing");
+
       // Subcommand to test entropy of random number generation.
       auto entropy = test->add_subcommand(
         "debug_entropy",
@@ -290,7 +294,8 @@ namespace trieste
             .start_seed(test_seed)
             .bound_vars(bound_vars)
             .test_sequence(test_sequence)
-            .size_stats(test_size_stats);
+            .size_stats(test_size_stats)
+            .oracle(oracle);
 
         if (*entropy)
         {

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -153,10 +153,12 @@ namespace trieste
         "--oracle", oracle, "Act as an oracle for differential testing");
 
       std::filesystem::path path_to_oracle;
-      test->add_option(
-        "--diff",
-        path_to_oracle,
-        "Path to the oracle for differential testing")->excludes(oracle_opt);
+      test
+        ->add_option(
+          "--diff",
+          path_to_oracle,
+          "Path to the oracle for differential testing")
+        ->excludes(oracle_opt);
 
       // Subcommand to test entropy of random number generation.
       auto entropy = test->add_subcommand(
@@ -275,23 +277,22 @@ namespace trieste
         size_t max_retries =
           test_max_retries ? *test_max_retries : test_seed_count * 2;
 
-        std::string oracle_command =
-          path_to_oracle.empty() ? "" :
-          path_to_oracle.string() +
-          " test -l None --oracle" +
-          " -c " + std::to_string(test_seed_count) +
-          " -s " + std::to_string(test_seed) +
-          " -d " + std::to_string(test_max_depth) +
-          " -r " + std::to_string(max_retries) +
-          " --gen_bound " + (bound_vars ? "true" : "false");
+        std::string oracle_command = path_to_oracle.empty() ?
+          "" :
+          path_to_oracle.string() + " test -l None --oracle" + " -c " +
+            std::to_string(test_seed_count) + " -s " +
+            std::to_string(test_seed) + " -d " +
+            std::to_string(test_max_depth) + " -r " +
+            std::to_string(max_retries) + " --gen_bound " +
+            (bound_vars ? "true" : "false");
 
         logging::Output() << "Testing x" << test_seed_count
                           << ", seed: " << test_seed << std::endl;
 
         if (!oracle_command.empty())
         {
-          logging::Output() << "Using oracle command: " << oracle_command << " <pass_name>"
-                            << std::endl;
+          logging::Output() << "Using oracle command: " << oracle_command
+                            << " <pass_name>" << std::endl;
         }
 
         if (test_start_pass.empty())

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -149,8 +149,14 @@ namespace trieste
         "--gen_bound", bound_vars, "Generate bound variable names if possible");
 
       auto oracle = false;
-      test->add_flag(
+      auto oracle_opt = test->add_flag(
         "--oracle", oracle, "Act as an oracle for differential testing");
+
+      std::filesystem::path path_to_oracle;
+      test->add_option(
+        "--diff",
+        path_to_oracle,
+        "Path to the oracle for differential testing")->excludes(oracle_opt);
 
       // Subcommand to test entropy of random number generation.
       auto entropy = test->add_subcommand(
@@ -266,8 +272,27 @@ namespace trieste
           return 1;
         }
 
+        size_t max_retries =
+          test_max_retries ? *test_max_retries : test_seed_count * 2;
+
+        std::string oracle_command =
+          path_to_oracle.empty() ? "" :
+          path_to_oracle.string() +
+          " test -l None --oracle" +
+          " -c " + std::to_string(test_seed_count) +
+          " -s " + std::to_string(test_seed) +
+          " -d " + std::to_string(test_max_depth) +
+          " -r " + std::to_string(max_retries) +
+          " --gen_bound " + (bound_vars ? "true" : "false");
+
         logging::Output() << "Testing x" << test_seed_count
                           << ", seed: " << test_seed << std::endl;
+
+        if (!oracle_command.empty())
+        {
+          logging::Output() << "Using oracle command: " << oracle_command << " <pass_name>"
+                            << std::endl;
+        }
 
         if (test_start_pass.empty())
         {
@@ -284,8 +309,7 @@ namespace trieste
 
         Fuzzer fuzzer =
           Fuzzer(reader)
-            .max_retries(
-              test_max_retries ? *test_max_retries : test_seed_count * 2)
+            .max_retries(max_retries)
             .max_depth(test_max_depth)
             .failfast(test_failfast)
             .seed_count(test_seed_count)
@@ -295,7 +319,9 @@ namespace trieste
             .bound_vars(bound_vars)
             .test_sequence(test_sequence)
             .size_stats(test_size_stats)
-            .oracle(oracle);
+            .test_diff(!path_to_oracle.empty())
+            .oracle_command(oracle_command)
+            .run_as_oracle(oracle);
 
         if (*entropy)
         {

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -25,6 +25,7 @@ namespace trieste
     bool bound_vars_;
     bool test_sequence_;
     bool size_stats_;
+    bool oracle_;
 
     struct SeedContext
     {
@@ -309,6 +310,11 @@ namespace trieste
 
         auto ast = gen_ast(prev, seed_context);
 
+        if (oracle_)
+        {
+          std::cout << ast;
+        }
+
         logging::Trace() << "============" << std::endl
                          << "Pass: " << pass->name()
                          << ", seed: " << seed_context.current_seed << std::endl
@@ -354,6 +360,12 @@ namespace trieste
             {new_ast,
              seed_context.current_seed,
              pass_stats.change_count - old_changes});
+        }
+
+        if (oracle_)
+        {
+          std::cout << new_ast;
+          std::cout << (result == RunResult::FAIL ? "FAIL" : "OK") << std::endl;
         }
       }
 
@@ -478,7 +490,8 @@ namespace trieste
       max_retries_(100),
       bound_vars_(true),
       test_sequence_(false),
-      size_stats_(false)
+      size_stats_(false),
+      oracle_(false)
     {}
 
     Fuzzer(const Reader& reader)
@@ -595,6 +608,17 @@ namespace trieste
     Fuzzer& size_stats(bool size_stats)
     {
       size_stats_ = size_stats;
+      return *this;
+    }
+
+    bool oracle() const
+    {
+      return oracle_;
+    }
+
+    Fuzzer& oracle(bool oracle)
+    {
+      oracle_ = oracle;
       return *this;
     }
 

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -475,7 +475,11 @@ namespace trieste
           expected_output += line;
         }
 
-        fgets(buffer, sizeof(buffer), oracle_output);
+        if (!fgets(buffer, sizeof(buffer), oracle_output))
+        {
+          logging::Error() << "Failed to read oracle output" << std::endl;
+          return pass_stats;
+        }
         std::string result_str(buffer);
         RunResult result = (result_str.find("FAIL") != std::string::npos) ?
           RunResult::FAIL :

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -437,15 +437,14 @@ namespace trieste
       return pass_stats;
     }
 
-    PassStats test_pass_with_oracle(
-      Pass& pass,
-      const trieste::wf::Wellformed& prev)
+    PassStats
+    test_pass_with_oracle(Pass& pass, const trieste::wf::Wellformed& prev)
     {
       PassStats pass_stats;
 
       // Run the oracle on the pass and collect trees and results.
       std::string oracle_command = oracle_command_ + " '" + pass->name() + "'";
-      FILE *oracle_output = popen(oracle_command.c_str(), "r");
+      FILE* oracle_output = popen(oracle_command.c_str(), "r");
 
       if (!oracle_output)
       {
@@ -463,25 +462,27 @@ namespace trieste
         while (fgets(buffer, sizeof(buffer), oracle_output))
         {
           std::string line(buffer);
-          if (line == "\n") break;
+          if (line == "\n")
+            break;
           generated_input += line;
         }
 
         while (fgets(buffer, sizeof(buffer), oracle_output))
         {
           std::string line(buffer);
-          if (line == "\n") break;
+          if (line == "\n")
+            break;
           expected_output += line;
         }
 
         fgets(buffer, sizeof(buffer), oracle_output);
         std::string result_str(buffer);
-        RunResult result = (result_str.find("FAIL") != std::string::npos)
-        ? RunResult::FAIL
-        : RunResult::OK;
+        RunResult result = (result_str.find("FAIL") != std::string::npos) ?
+          RunResult::FAIL :
+          RunResult::OK;
 
         // TODO: Use this for checking
-        (void) result;
+        (void)result;
 
         auto input_source = SourceDef::synthetic(generated_input);
         auto expected_source = SourceDef::synthetic(expected_output);
@@ -504,7 +505,8 @@ namespace trieste
           return pass_stats;
         }
 
-        auto [new_ast, pass_result] = run_pass(input_tree, pass, pass->wf(), pass_stats);
+        auto [new_ast, pass_result] =
+          run_pass(input_tree, pass, pass->wf(), pass_stats);
 
         auto [lhs, rhs] = new_ast->diff(expected_tree);
         if (lhs || rhs)
@@ -526,11 +528,9 @@ namespace trieste
             err << "<missing>" << std::endl;
 
           err << "------------" << std::endl
-              << generated_input
-              << "------------" << std::endl
+              << generated_input << "------------" << std::endl
               << "oracle output:" << std::endl
-              << expected_output
-              << "------------" << std::endl
+              << expected_output << "------------" << std::endl
               << "resulting output:" << std::endl
               << new_ast;
 
@@ -540,7 +540,6 @@ namespace trieste
           if (failfast_)
             break;
         }
-
       }
       pclose(oracle_output);
       return pass_stats;
@@ -846,7 +845,8 @@ namespace trieste
 
       if (test_diff_ && run_as_oracle_)
       {
-        logging::Error() << "cannot both act as oracle and test diffs" << std::endl;
+        logging::Error() << "cannot both act as oracle and test diffs"
+                         << std::endl;
         return 1;
       }
 

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -25,7 +25,9 @@ namespace trieste
     bool bound_vars_;
     bool test_sequence_;
     bool size_stats_;
-    bool oracle_;
+    bool test_diff_;
+    std::string oracle_command_;
+    bool run_as_oracle_;
 
     struct SeedContext
     {
@@ -50,6 +52,8 @@ namespace trieste
       size_t error_count = 0;
       size_t change_count = 0;
 
+      size_t diff_count = 0;
+
       std::vector<size_t> passed_sizes;
       std::vector<size_t> passed_heights;
       std::vector<size_t> error_sizes;
@@ -65,6 +69,9 @@ namespace trieste
         if (failed_count > 0)
           info << "  " << failed_count << " well-formedness errors."
                << std::endl;
+
+        if (diff_count > 0)
+          info << "  " << diff_count << " different from oracle." << std::endl;
 
         if (error_count > 0)
         {
@@ -310,9 +317,9 @@ namespace trieste
 
         auto ast = gen_ast(prev, seed_context);
 
-        if (oracle_)
+        if (run_as_oracle_)
         {
-          std::cout << ast;
+          std::cout << ast << std::endl;
         }
 
         logging::Trace() << "============" << std::endl
@@ -362,9 +369,9 @@ namespace trieste
              pass_stats.change_count - old_changes});
         }
 
-        if (oracle_)
+        if (run_as_oracle_)
         {
-          std::cout << new_ast;
+          std::cout << new_ast << std::endl;
           std::cout << (result == RunResult::FAIL ? "FAIL" : "OK") << std::endl;
         }
       }
@@ -430,6 +437,115 @@ namespace trieste
       return pass_stats;
     }
 
+    PassStats test_pass_with_oracle(
+      Pass& pass,
+      const trieste::wf::Wellformed& prev)
+    {
+      PassStats pass_stats;
+
+      // Run the oracle on the pass and collect trees and results.
+      std::string oracle_command = oracle_command_ + " '" + pass->name() + "'";
+      FILE *oracle_output = popen(oracle_command.c_str(), "r");
+
+      if (!oracle_output)
+      {
+        logging::Error() << "Failed to run oracle command: " << oracle_command
+                         << std::endl;
+        return pass_stats;
+      }
+
+      for (size_t i = 0; i < seed_count_; i++)
+      {
+        char buffer[1024];
+        std::string generated_input;
+        std::string expected_output;
+
+        while (fgets(buffer, sizeof(buffer), oracle_output))
+        {
+          std::string line(buffer);
+          if (line == "\n") break;
+          generated_input += line;
+        }
+
+        while (fgets(buffer, sizeof(buffer), oracle_output))
+        {
+          std::string line(buffer);
+          if (line == "\n") break;
+          expected_output += line;
+        }
+
+        fgets(buffer, sizeof(buffer), oracle_output);
+        std::string result_str(buffer);
+        RunResult result = (result_str.find("FAIL") != std::string::npos)
+        ? RunResult::FAIL
+        : RunResult::OK;
+
+        // TODO: Use this for checking
+        (void) result;
+
+        auto input_source = SourceDef::synthetic(generated_input);
+        auto expected_source = SourceDef::synthetic(expected_output);
+
+        auto input_tree = build_ast(input_source, 0);
+        if (!input_tree)
+        {
+          logging::Error() << "Failed to parse oracle input: " << std::endl
+                           << generated_input << std::endl;
+          return pass_stats;
+        }
+
+        prev.build_st(input_tree);
+
+        auto expected_tree = build_ast(expected_source, 0);
+        if (!expected_tree)
+        {
+          logging::Error() << "Failed to parse oracle output: " << std::endl
+                           << expected_output << std::endl;
+          return pass_stats;
+        }
+
+        auto [new_ast, pass_result] = run_pass(input_tree, pass, pass->wf(), pass_stats);
+
+        auto [lhs, rhs] = new_ast->diff(expected_tree);
+        if (lhs || rhs)
+        {
+          pass_stats.diff_count++;
+          logging::Error err;
+          err << "============" << std::endl
+              << "in oracle output:" << std::endl;
+          if (rhs)
+            err << rhs;
+          else
+            err << "<missing>" << std::endl;
+
+          err << "------------" << std::endl
+              << "in resulting output:" << std::endl;
+          if (lhs)
+            err << lhs;
+          else
+            err << "<missing>" << std::endl;
+
+          err << "------------" << std::endl
+              << generated_input
+              << "------------" << std::endl
+              << "oracle output:" << std::endl
+              << expected_output
+              << "------------" << std::endl
+              << "resulting output:" << std::endl
+              << new_ast;
+
+          err << "============" << std::endl
+              << "Oracle mismatch for pass: " << pass->name() << std::endl;
+
+          if (failfast_)
+            break;
+        }
+
+      }
+      pclose(oracle_output);
+      return pass_stats;
+    }
+
     double calculate_entropy(std::vector<uint8_t>& byte_values)
     {
       std::map<uint8_t, double> freq;
@@ -491,7 +607,9 @@ namespace trieste
       bound_vars_(true),
       test_sequence_(false),
       size_stats_(false),
-      oracle_(false)
+      test_diff_(false),
+      oracle_command_(),
+      run_as_oracle_(false)
     {}
 
     Fuzzer(const Reader& reader)
@@ -611,14 +729,36 @@ namespace trieste
       return *this;
     }
 
-    bool oracle() const
+    bool test_diff() const
     {
-      return oracle_;
+      return test_diff_;
     }
 
-    Fuzzer& oracle(bool oracle)
+    Fuzzer& test_diff(bool test_diff)
     {
-      oracle_ = oracle;
+      test_diff_ = test_diff;
+      return *this;
+    }
+
+    std::string oracle_command() const
+    {
+      return oracle_command_;
+    }
+
+    Fuzzer& oracle_command(const std::string& oracle_command)
+    {
+      oracle_command_ = oracle_command;
+      return *this;
+    }
+
+    bool run_as_oracle() const
+    {
+      return run_as_oracle_;
+    }
+
+    Fuzzer& run_as_oracle(bool run_as_oracle)
+    {
+      run_as_oracle_ = run_as_oracle;
       return *this;
     }
 
@@ -703,6 +843,20 @@ namespace trieste
         logging::Error() << "pass range is empty" << std::endl;
         return 1;
       }
+
+      if (test_diff_ && run_as_oracle_)
+      {
+        logging::Error() << "cannot both act as oracle and test diffs" << std::endl;
+        return 1;
+      }
+
+      if (test_diff_ && oracle_command_.empty())
+      {
+        logging::Error() << "path to oracle must be provided when testing diffs"
+                         << std::endl;
+        return 1;
+      }
+
       WFContext context;
       SequenceStats sequence_stats(end_index_ - start_index_ + 1, seed_count_);
       std::vector<Survivor> survivors;
@@ -734,11 +888,11 @@ namespace trieste
         seed_context.retry_seed = start_seed_ + seed_count_;
 
         PassStats pass_stats;
-        if (!test_sequence_ || i == start_index_)
+        if (!test_diff_ && (!test_sequence_ || i == start_index_))
         {
           pass_stats = test_pass(pass, prev, seed_context);
         }
-        else
+        else if (test_sequence_)
         {
           logging::Info() << "  " << survivors.size()
                           << " survivors from previous pass.";
@@ -750,8 +904,12 @@ namespace trieste
           }
           pass_stats = test_pass_with_survivors(pass, survivors);
         }
+        else if (test_diff_)
+        {
+          pass_stats = test_pass_with_oracle(pass, prev);
+        }
 
-        if (pass_stats.failed_count > 0)
+        if (pass_stats.failed_count > 0 || pass_stats.diff_count > 0)
         {
           ret = 1;
           if (failfast_)


### PR DESCRIPTION
This pull request adds support for per-pass differential testing. It works by supplying the path to another implementation which acts as an oracle and generates input and expected output:
```
$ ./my_compiler test --diff /path/to/oracle
Testing x100, seed: 123456789

Using oracle command: ./path/to/oracle test -l None --oracle -c 100 -s 123456789 -d 10 -r 200 --gen_bound true <pass_name>

============
in oracle output:
(infix-ref
  (infix-ident 2:$3))
------------
in resulting output:
(error
  (errormsg 9:undefined)
  (errorast
    (infix-ident 2:$3)))
------------
<input tree>
------------
oracle output:
<tree>
------------
resulting output:
<tree>
============
Oracle mismatch for pass: my_pass
```
The oracle prints input/output pairs to stdout together with an indicator of well-formedness (OK or FAIL). The implementation under test reports whenever a tree does not match the expected output, presenting the first sub-tree that is different in the two trees.

This is opened as a draft to enable discussion. Below is a list of outstanding TODOs.

### TODO
- [ ] Figure out how to deal with failures from the oracle
  - If the oracle has a wellformedness error but the implementation under test does not, it can be argued that we have fixed a bug and therefore shouldn't report it even though there is a difference in the output.
- [ ] Also support differential testing for sequences
  - The current design works pass by pass in order to avoid having to wait for the oracle to finish all its output, being able to abort early, etc. This is not compatible with the sequence testing which carries survivors between passes, and where it is not as clear how many trees there are to parse.
- [ ] Think about whether there is a more compact error reporting than printing all three trees, plus sub-trees.
  - The output of even a single error is currently quite noisy. One approach would be to print a single resulting tree where the diff is highlighted somehow.
- [ ] Get I/O working on Windows.