### PR TITLE
Compute `pass_through` correctly for sequences

### DIFF
--- a/include/trieste/pass.h
+++ b/include/trieste/pass.h
@@ -217,14 +217,16 @@ namespace trieste
       {
         const auto& starts = rule.first.value.get_starts();
         const auto& parents = rule.first.value.get_parents();
+        const bool is_pass_through = rule.first.value.is_pass_through();
 
         //  This is used to add a rule under a specific parent, or to the
         //  default.
         auto add = [&](detail::DefaultMap<
                        std::vector<detail::PatternEffect<Node>>>& rules) {
-          if (starts.empty())
+          if (starts.empty() || is_pass_through)
           {
-            // If there are no starts, then this rule applies to all tokens.
+            // If there are no starts, or the pattern is pass-through (may
+            // consume nothing), then this rule applies to all tokens.
             rules.modify_all([&](std::vector<detail::PatternEffect<Node>>& v) {
               v.push_back(rule);
             });

--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -239,6 +239,7 @@ namespace trieste
             // Union starts.
             new_first = lhs.starts;
             new_first.insert(rhs.starts.begin(), rhs.starts.end());
+            new_pass_through = rhs.pass_through;
           }
         }
         else
@@ -293,6 +294,11 @@ namespace trieste
       const std::set<Token>& get_parents() const
       {
         return parents;
+      }
+
+      bool is_pass_through() const
+      {
+        return pass_through;
       }
     };
 
@@ -1198,6 +1204,11 @@ namespace trieste
       const std::set<Token>& get_parents() const
       {
         return fast_pattern.get_parents();
+      }
+
+      bool is_pass_through() const
+      {
+        return fast_pattern.is_pass_through();
       }
     };
 


### PR DESCRIPTION
This PR fixes an issue where the `FastPattern` computation would always consider a sequence as having no passthrough. This meant that a pattern like `In(Foo) * Start * T(Bar)` would not end up with `Bar` in its start set (instead it would apply to all tokens in `Foo`, which is less efficient). Passthrough also needs to be checked during pattern compilation as a sequence of only passthrough patterns (which may consume zero nodes) that has a non-empty start set otherwise is only applied when the next token is in that start set. 

Because this only improves efficiency of pattern compilation, there is no regression to test. However, the Shrubbery example contains a sequence pattern with a non-empty start set but that is passthrough:
```c++
In(Group) * Start * (!T(Block, Alt))++[Atom] * ~T(Block)[Block] * ~T(Alt)[Alt] * End
```