### PR TITLE
Add support for token weights during fuzzing

### DIFF
--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -275,8 +275,8 @@ namespace trieste
           auto token = detail::find_token(name);
           if (token == Invalid)
           {
-            logging::Error() << "Unknown token in weights: " << name
-                             << std::endl;
+            logging::Error()
+              << "Unknown token in weights: " << name << std::endl;
             return 1;
           }
           parsed_weights[token] = weight;

--- a/include/trieste/driver.h
+++ b/include/trieste/driver.h
@@ -148,6 +148,13 @@ namespace trieste
       test->add_option(
         "--gen_bound", bound_vars, "Generate bound variable names if possible");
 
+      std::vector<std::tuple<std::string, size_t>> test_weights;
+      test->add_option(
+        "--weights",
+        test_weights,
+        "Token weight pairs for generation. Use: --weights <token> <weight> "
+        "[<token> <weight> ...]");
+
       // Subcommand to test entropy of random number generation.
       auto entropy = test->add_subcommand(
         "debug_entropy",
@@ -262,6 +269,19 @@ namespace trieste
           return 1;
         }
 
+        wf::TokenWeights parsed_weights;
+        for (auto [name, weight] : test_weights)
+        {
+          auto token = detail::find_token(name);
+          if (token == Invalid)
+          {
+            logging::Error() << "Unknown token in weights: " << name
+                             << std::endl;
+            return 1;
+          }
+          parsed_weights[token] = weight;
+        }
+
         logging::Output() << "Testing x" << test_seed_count
                           << ", seed: " << test_seed << std::endl;
 
@@ -289,6 +309,7 @@ namespace trieste
             .end_index(reader.pass_index(test_end_pass))
             .start_seed(test_seed)
             .bound_vars(bound_vars)
+            .token_weights(std::move(parsed_weights))
             .test_sequence(test_sequence)
             .size_stats(test_size_stats);
 

--- a/include/trieste/fuzzer.h
+++ b/include/trieste/fuzzer.h
@@ -23,6 +23,7 @@ namespace trieste
     size_t end_index_;
     size_t max_retries_;
     bool bound_vars_;
+    wf::TokenWeights token_weights_;
     bool test_sequence_;
     bool size_stats_;
 
@@ -209,15 +210,23 @@ namespace trieste
     /// @return The generated AST node.
     Node gen_ast(const wf::Wellformed& wf, SeedContext& context)
     {
-      auto ast =
-        wf.gen(generators_, context.current_seed, max_depth_, bound_vars_);
+      auto ast = wf.gen(
+        generators_,
+        context.current_seed,
+        max_depth_,
+        bound_vars_,
+        token_weights_);
       size_t hash = ast->hash();
       while (context.ast_hashes.find(hash) != context.ast_hashes.end() &&
              context.retries < max_retries_)
       {
         context.current_seed = context.retry_seed++;
-        ast =
-          wf.gen(generators_, context.current_seed, max_depth_, bound_vars_);
+        ast = wf.gen(
+          generators_,
+          context.current_seed,
+          max_depth_,
+          bound_vars_,
+          token_weights_);
         hash = ast->hash();
         context.retries++;
       }
@@ -477,6 +486,7 @@ namespace trieste
       end_index_(passes.size()),
       max_retries_(100),
       bound_vars_(true),
+      token_weights_({}),
       test_sequence_(false),
       size_stats_(false)
     {}
@@ -669,6 +679,12 @@ namespace trieste
     Fuzzer& bound_vars(bool gen_bound_vars)
     {
       bound_vars_ = gen_bound_vars;
+      return *this;
+    }
+
+    Fuzzer& token_weights(wf::TokenWeights token_weights)
+    {
+      token_weights_ = std::move(token_weights);
       return *this;
     }
 

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -495,7 +495,11 @@ namespace trieste
         for (i = 0; i < min_len; ++i)
           choice.gen(g, depth, node);
 
-        if (depth >= g.target_depth)
+        auto weight_sum = 0;
+        for (const auto& t : choice.types)
+          weight_sum += g.weight_for(t);
+
+        if (depth >= g.target_depth || weight_sum == 0)
         {
           return;
         }

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -497,9 +497,11 @@ namespace trieste
         for (i = 0; i < min_len; ++i)
           choice.gen(g, depth, node);
 
-        auto weight_sum = 0;
-        for (const auto& t : choice.types)
-          weight_sum += g.weight_for(t);
+        const auto weight_sum = std::accumulate(
+          choice.types.begin(),
+          choice.types.end(),
+          size_t{0},
+          [&](size_t acc, const Token& t) { return acc + g.weight_for(t); });
 
         if (depth >= g.target_depth || weight_sum == 0)
         {

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -25,6 +25,7 @@ namespace trieste
   namespace wf
   {
     using TokenTerminalDistance = std::map<Token, std::size_t>;
+    using TokenWeights = std::map<Token, std::size_t>;
     using SymtabKeys = std::pair<std::vector<Token>, size_t>;
 
     struct Gen
@@ -35,6 +36,7 @@ namespace trieste
       size_t target_depth;
       size_t ceiling_depth;
       double alpha;
+      TokenWeights token_weights_;
       std::map<Token, std::pair<std::vector<Token>, size_t>> binding_keys;
       bool gen_bound_vars;
 
@@ -80,15 +82,94 @@ namespace trieste
         return std::find(tokens.begin(), tokens.end(), t) != tokens.end();
       }
 
-      Token choose(const std::vector<Token>& tokens, std::size_t depth)
+      Gen& token_weights(TokenWeights token_weights)
       {
+        token_weights_ = std::move(token_weights);
+        return *this;
+      }
+
+      std::size_t weight_for(const Token& token) const
+      {
+        auto it = token_weights_.find(token);
+        if (it == token_weights_.end())
+          return 1;
+
+        return it->second;
+      }
+
+      [[noreturn]] void throw_no_candidates(
+        const std::vector<Token>& tokens,
+        Token parent,
+        std::size_t depth,
+        const std::string& reason) const
+      {
+        std::ostringstream err;
+        err << "Cannot choose token for parent " << parent.str() << " at depth "
+            << depth << ": " << reason << std::endl;
+        err << "tokens={";
+        std::string delim = "";
+        for (auto const& token : tokens)
+        {
+          err << delim << token.str() << ":" << weight_for(token);
+          delim = ", ";
+        }
+        err << "}";
+        throw std::runtime_error(err.str());
+      }
+
+      Token choose_weighted(
+        const std::vector<Token>& tokens,
+        std::vector<double> offsets,
+        Token parent,
+        std::size_t depth)
+      {
+        // compute the cumulative distribution of the given offsets
+        std::partial_sum(offsets.begin(), offsets.end(), offsets.begin());
+
+        if (offsets.empty() || offsets.back() <= 0.0)
+          throw_no_candidates(tokens, parent, depth, "no positive effective weights");
+
+        // instead of normalising the distribution, scale the random value by
+        // the sum of the weights
+        double value = static_cast<double>(rand() - rand.min()) /
+          static_cast<double>(rand.max() - rand.min()) * offsets.back();
+
+        // finding the first element greater than the uniform random number is
+        // the same as performing a weighted sampling of the distribution
+        auto it = std::lower_bound(offsets.begin(), offsets.end(), value);
+
+        return tokens[std::distance(offsets.begin(), it)];
+      }
+
+      Token choose(const std::vector<Token>& tokens, std::size_t depth, Token parent)
+      {
+        if (tokens.empty())
+          throw_no_candidates(tokens, parent, depth, "empty token list");
+
         if (tokens.size() == 1)
         {
+          if (!token_weights_.empty() && weight_for(tokens[0]) == 0)
+            throw_no_candidates(
+              tokens, parent, depth, "single token has zero effective weight");
           return tokens[0];
         }
 
         if (depth <= target_depth)
         {
+          if (!token_weights_.empty())
+          {
+            std::vector<double> offsets;
+            offsets.reserve(tokens.size());
+            std::transform(
+              tokens.begin(),
+              tokens.end(),
+              std::back_inserter(offsets),
+              [&](const Token& t) {
+                return static_cast<double>(weight_for(t));
+              });
+            return choose_weighted(tokens, std::move(offsets), parent, depth);
+          }
+
           std::size_t choice = rand() % tokens.size();
           return tokens[choice];
         }
@@ -147,20 +228,14 @@ namespace trieste
           return tokens[std::distance(offsets.begin(), max)];
         }
 
-        // compute the cumulative distribution of P(d | c, p)
-        std::partial_sum(offsets.begin(), offsets.end(), offsets.begin());
+        if (!token_weights_.empty())
+        {
+          // scale the offsets by the token weights
+          for (size_t i = 0; i < offsets.size(); i++)
+            offsets[i] *= static_cast<double>(weight_for(tokens[i]));
+        }
 
-        // instead of normalizing the cumulative distribution, scale the random
-        // number to the sum of the probabilities
-        double value = static_cast<double>(rand() - rand.min()) /
-          static_cast<double>(rand.max() - rand.min()) * offsets.back();
-
-        // finding the first element greater than the uniform random number is
-        // the same as performing a weighted sampling of the P(c | d, p)
-        // distribution
-        auto it = std::lower_bound(offsets.begin(), offsets.end(), value);
-
-        return tokens[std::distance(offsets.begin(), it)];
+        return choose_weighted(tokens, std::move(offsets), parent, depth);
       }
 
       Result next()
@@ -304,7 +379,7 @@ namespace trieste
 
       void gen(Gen& g, size_t depth, Node node) const
       {
-        Token type = g.choose(types, depth);
+        Token type = g.choose(types, depth, node->type());
 
         // We may need a fresh location, so the child needs to be in the AST by
         // the time we call g.location().
@@ -774,7 +849,12 @@ namespace trieste
 
     public:
       Node
-      gen(GenNodeLocationF gloc, Seed seed, size_t target_depth, bool gen_bound)
+      gen(
+        GenNodeLocationF gloc,
+        Seed seed,
+        size_t target_depth,
+        bool gen_bound,
+        TokenWeights token_weights = {})
         const
       {
         // Collect map of tokens to their binding token and the corresponding
@@ -789,7 +869,8 @@ namespace trieste
           seed,
           target_depth,
           binding_keys,
-          gen_bound);
+          gen_bound)
+          .token_weights(std::move(token_weights));
         auto top = NodeDef::create(Top);
         ast::detail::top_node() = top;
         gen_node(g, 0, top);

--- a/include/trieste/wf.h
+++ b/include/trieste/wf.h
@@ -127,7 +127,8 @@ namespace trieste
         std::partial_sum(offsets.begin(), offsets.end(), offsets.begin());
 
         if (offsets.empty() || offsets.back() <= 0.0)
-          throw_no_candidates(tokens, parent, depth, "no positive effective weights");
+          throw_no_candidates(
+            tokens, parent, depth, "no positive effective weights");
 
         // instead of normalising the distribution, scale the random value by
         // the sum of the weights
@@ -141,7 +142,8 @@ namespace trieste
         return tokens[std::distance(offsets.begin(), it)];
       }
 
-      Token choose(const std::vector<Token>& tokens, std::size_t depth, Token parent)
+      Token
+      choose(const std::vector<Token>& tokens, std::size_t depth, Token parent)
       {
         if (tokens.empty())
           throw_no_candidates(tokens, parent, depth, "empty token list");
@@ -852,14 +854,12 @@ namespace trieste
       }
 
     public:
-      Node
-      gen(
+      Node gen(
         GenNodeLocationF gloc,
         Seed seed,
         size_t target_depth,
         bool gen_bound,
-        TokenWeights token_weights = {})
-        const
+        TokenWeights token_weights = {}) const
       {
         // Collect map of tokens to their binding token and the corresponding
         // index
@@ -868,13 +868,13 @@ namespace trieste
           populate_binding_keys(binding_keys);
 
         auto g = Gen(
-          compute_minimum_distance_to_terminal(target_depth),
-          gloc,
-          seed,
-          target_depth,
-          binding_keys,
-          gen_bound)
-          .token_weights(std::move(token_weights));
+                   compute_minimum_distance_to_terminal(target_depth),
+                   gloc,
+                   seed,
+                   target_depth,
+                   binding_keys,
+                   gen_bound)
+                   .token_weights(std::move(token_weights));
         auto top = NodeDef::create(Top);
         ast::detail::top_node() = top;
         gen_node(g, 0, top);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,14 @@ target_link_libraries(trieste_roundtrip_test trieste::trieste)
 
 add_test(NAME trieste_roundtrip_test COMMAND trieste_roundtrip_test WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_roundtrip_test>)
 
+add_executable(trieste_token_weights_test
+  token_weights_test.cc
+)
+enable_warnings(trieste_token_weights_test)
+target_link_libraries(trieste_token_weights_test trieste::trieste)
+
+add_test(NAME trieste_token_weights_test COMMAND trieste_token_weights_test WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_token_weights_test>)
+
 if(TRIESTE_BUILD_REGEX_BENCHMARK)
   include(FetchContent)
 

--- a/test/roundtrip_test.cc
+++ b/test/roundtrip_test.cc
@@ -10,8 +10,6 @@ namespace
   inline const auto TestPrint = TokenDef("test-print", flag::print);
   inline const auto TestNode = TokenDef("test-node");
   inline const auto TestRoot = TokenDef("test-root");
-  inline const auto WeightA = TokenDef("test-weight-a");
-  inline const auto WeightB = TokenDef("test-weight-b");
 
   // Check that a specific str() output matches an expected string.
   bool
@@ -133,120 +131,11 @@ namespace
     return ok;
   }
 
-  bool check_wf_token_weights()
-  {
-    auto ok = true;
-    auto gloc = [](Rand&, Node) { return Location(); };
-    std::vector<Token> choices = {WeightA, WeightB};
-
-    // Zero-weight tokens should never be selected when a positive candidate
-    // exists in the probabilistic branches.
-    {
-      auto g = wf::Gen(
-                 wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
-                 gloc,
-                 123,
-                 5,
-                 {},
-                 false)
-                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 5}});
-
-      for (size_t i = 0; i < 64; i++)
-      {
-        if (g.choose(choices, 0, Top) != WeightB)
-        {
-          std::cout << "wf_token_weights: selected zero-weight token at depth 0"
-                    << std::endl;
-          ok = false;
-          break;
-        }
-      }
-    }
-
-    // All-zero weights are invalid at a choice point.
-    {
-      auto g = wf::Gen(
-                 wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
-                 gloc,
-                 321,
-                 5,
-                 {},
-                 false)
-                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 0}});
-
-      bool threw = false;
-      try
-      {
-        (void)g.choose(choices, 0, Top);
-      }
-      catch (const std::runtime_error&)
-      {
-        threw = true;
-      }
-
-      if (!threw)
-      {
-        std::cout << "wf_token_weights: expected throw for all-zero weights"
-                  << std::endl;
-        ok = false;
-      }
-    }
-
-    // A singleton choice with zero weight should also fail.
-    {
-      auto g =
-        wf::Gen(
-          wf::TokenTerminalDistance{{WeightA, 1}}, gloc, 111, 5, {}, false)
-          .token_weights(wf::TokenWeights{{WeightA, 0}});
-
-      bool threw = false;
-      try
-      {
-        (void)g.choose(std::vector<Token>{WeightA}, 0, Top);
-      }
-      catch (const std::runtime_error&)
-      {
-        threw = true;
-      }
-
-      if (!threw)
-      {
-        std::cout
-          << "wf_token_weights: expected throw for zero-weight singleton"
-          << std::endl;
-        ok = false;
-      }
-    }
-
-    // Ceiling fallback remains distance-driven, ignoring token weights.
-    {
-      auto g = wf::Gen(
-                 wf::TokenTerminalDistance{{WeightA, 0}, {WeightB, 10}},
-                 gloc,
-                 222,
-                 1,
-                 {},
-                 false)
-                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 100}});
-
-      if (g.choose(choices, 2, Top) != WeightA)
-      {
-        std::cout << "wf_token_weights: ceiling fallback ignored distance"
-                  << std::endl;
-        ok = false;
-      }
-    }
-
-    return ok;
-  }
 }
 
 int main()
 {
   int failures = 0;
-
-  if (!check_wf_token_weights())
-    failures++;
 
   // Case 1: No location, no print — bare token.
   {

--- a/test/roundtrip_test.cc
+++ b/test/roundtrip_test.cc
@@ -130,7 +130,6 @@ namespace
 
     return ok;
   }
-
 }
 
 int main()

--- a/test/roundtrip_test.cc
+++ b/test/roundtrip_test.cc
@@ -10,6 +10,8 @@ namespace
   inline const auto TestPrint = TokenDef("test-print", flag::print);
   inline const auto TestNode = TokenDef("test-node");
   inline const auto TestRoot = TokenDef("test-root");
+  inline const auto WeightA = TokenDef("test-weight-a");
+  inline const auto WeightB = TokenDef("test-weight-b");
 
   // Check that a specific str() output matches an expected string.
   bool
@@ -130,11 +132,124 @@ namespace
 
     return ok;
   }
+
+  bool check_wf_token_weights()
+  {
+    auto ok = true;
+    auto gloc = [](Rand&, Node) { return Location(); };
+    std::vector<Token> choices = {WeightA, WeightB};
+
+    // Zero-weight tokens should never be selected when a positive candidate
+    // exists in the probabilistic branches.
+    {
+      auto g = wf::Gen(
+        wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
+        gloc,
+        123,
+        5,
+        {},
+        false)
+        .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 5}});
+
+      for (size_t i = 0; i < 64; i++)
+      {
+        if (g.choose(choices, 0, Top) != WeightB)
+        {
+          std::cout << "wf_token_weights: selected zero-weight token at depth 0"
+                    << std::endl;
+          ok = false;
+          break;
+        }
+      }
+    }
+
+    // All-zero weights are invalid at a choice point.
+    {
+      auto g = wf::Gen(
+        wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
+        gloc,
+        321,
+        5,
+        {},
+        false)
+        .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 0}});
+
+      bool threw = false;
+      try
+      {
+        (void)g.choose(choices, 0, Top);
+      }
+      catch (const std::runtime_error&)
+      {
+        threw = true;
+      }
+
+      if (!threw)
+      {
+        std::cout << "wf_token_weights: expected throw for all-zero weights"
+                  << std::endl;
+        ok = false;
+      }
+    }
+
+    // A singleton choice with zero weight should also fail.
+    {
+      auto g = wf::Gen(
+        wf::TokenTerminalDistance{{WeightA, 1}},
+        gloc,
+        111,
+        5,
+        {},
+        false)
+        .token_weights(wf::TokenWeights{{WeightA, 0}});
+
+      bool threw = false;
+      try
+      {
+        (void)g.choose(std::vector<Token>{WeightA}, 0, Top);
+      }
+      catch (const std::runtime_error&)
+      {
+        threw = true;
+      }
+
+      if (!threw)
+      {
+        std::cout << "wf_token_weights: expected throw for zero-weight singleton"
+                  << std::endl;
+        ok = false;
+      }
+    }
+
+    // Ceiling fallback remains distance-driven, ignoring token weights.
+    {
+      auto g = wf::Gen(
+        wf::TokenTerminalDistance{{WeightA, 0}, {WeightB, 10}},
+        gloc,
+        222,
+        1,
+        {},
+        false)
+        .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 100}});
+
+      if (g.choose(choices, 2, Top) != WeightA)
+      {
+        std::cout << "wf_token_weights: ceiling fallback ignored distance"
+                  << std::endl;
+        ok = false;
+      }
+    }
+
+    return ok;
+  }
 }
 
 int main()
 {
   int failures = 0;
+
+  if (!check_wf_token_weights())
+    failures++;
 
   // Case 1: No location, no print — bare token.
   {

--- a/test/roundtrip_test.cc
+++ b/test/roundtrip_test.cc
@@ -143,13 +143,13 @@ namespace
     // exists in the probabilistic branches.
     {
       auto g = wf::Gen(
-        wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
-        gloc,
-        123,
-        5,
-        {},
-        false)
-        .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 5}});
+                 wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
+                 gloc,
+                 123,
+                 5,
+                 {},
+                 false)
+                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 5}});
 
       for (size_t i = 0; i < 64; i++)
       {
@@ -166,13 +166,13 @@ namespace
     // All-zero weights are invalid at a choice point.
     {
       auto g = wf::Gen(
-        wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
-        gloc,
-        321,
-        5,
-        {},
-        false)
-        .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 0}});
+                 wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
+                 gloc,
+                 321,
+                 5,
+                 {},
+                 false)
+                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 0}});
 
       bool threw = false;
       try
@@ -194,14 +194,10 @@ namespace
 
     // A singleton choice with zero weight should also fail.
     {
-      auto g = wf::Gen(
-        wf::TokenTerminalDistance{{WeightA, 1}},
-        gloc,
-        111,
-        5,
-        {},
-        false)
-        .token_weights(wf::TokenWeights{{WeightA, 0}});
+      auto g =
+        wf::Gen(
+          wf::TokenTerminalDistance{{WeightA, 1}}, gloc, 111, 5, {}, false)
+          .token_weights(wf::TokenWeights{{WeightA, 0}});
 
       bool threw = false;
       try
@@ -215,8 +211,9 @@ namespace
 
       if (!threw)
       {
-        std::cout << "wf_token_weights: expected throw for zero-weight singleton"
-                  << std::endl;
+        std::cout
+          << "wf_token_weights: expected throw for zero-weight singleton"
+          << std::endl;
         ok = false;
       }
     }
@@ -224,13 +221,13 @@ namespace
     // Ceiling fallback remains distance-driven, ignoring token weights.
     {
       auto g = wf::Gen(
-        wf::TokenTerminalDistance{{WeightA, 0}, {WeightB, 10}},
-        gloc,
-        222,
-        1,
-        {},
-        false)
-        .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 100}});
+                 wf::TokenTerminalDistance{{WeightA, 0}, {WeightB, 10}},
+                 gloc,
+                 222,
+                 1,
+                 {},
+                 false)
+                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 100}});
 
       if (g.choose(choices, 2, Top) != WeightA)
       {

--- a/test/token_weights_test.cc
+++ b/test/token_weights_test.cc
@@ -1,0 +1,126 @@
+#include <iostream>
+#include <trieste/trieste.h>
+
+using namespace trieste;
+
+namespace
+{
+  inline const auto WeightA = TokenDef("test-weight-a");
+  inline const auto WeightB = TokenDef("test-weight-b");
+
+  bool check_wf_token_weights()
+  {
+    auto ok = true;
+    auto gloc = [](Rand&, Node) { return Location(); };
+    std::vector<Token> choices = {WeightA, WeightB};
+
+    // Zero-weight tokens should never be selected when a positive candidate
+    // exists in the probabilistic branches.
+    {
+      auto g = wf::Gen(
+                 wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
+                 gloc,
+                 123,
+                 5,
+                 {},
+                 false)
+                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 5}});
+
+      for (size_t i = 0; i < 64; i++)
+      {
+        if (g.choose(choices, 0, Top) != WeightB)
+        {
+          std::cout << "wf_token_weights: selected zero-weight token at depth 0"
+                    << std::endl;
+          ok = false;
+          break;
+        }
+      }
+    }
+
+    // All-zero weights are invalid at a choice point.
+    {
+      auto g = wf::Gen(
+                 wf::TokenTerminalDistance{{WeightA, 1}, {WeightB, 1}},
+                 gloc,
+                 321,
+                 5,
+                 {},
+                 false)
+                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 0}});
+
+      bool threw = false;
+      try
+      {
+        (void)g.choose(choices, 0, Top);
+      }
+      catch (const std::runtime_error&)
+      {
+        threw = true;
+      }
+
+      if (!threw)
+      {
+        std::cout << "wf_token_weights: expected throw for all-zero weights"
+                  << std::endl;
+        ok = false;
+      }
+    }
+
+    // A singleton choice with zero weight should also fail.
+    {
+      auto g =
+        wf::Gen(
+          wf::TokenTerminalDistance{{WeightA, 1}}, gloc, 111, 5, {}, false)
+          .token_weights(wf::TokenWeights{{WeightA, 0}});
+
+      bool threw = false;
+      try
+      {
+        (void)g.choose(std::vector<Token>{WeightA}, 0, Top);
+      }
+      catch (const std::runtime_error&)
+      {
+        threw = true;
+      }
+
+      if (!threw)
+      {
+        std::cout
+          << "wf_token_weights: expected throw for zero-weight singleton"
+          << std::endl;
+        ok = false;
+      }
+    }
+
+    // Ceiling fallback remains distance-driven, ignoring token weights.
+    {
+      auto g = wf::Gen(
+                 wf::TokenTerminalDistance{{WeightA, 0}, {WeightB, 10}},
+                 gloc,
+                 222,
+                 1,
+                 {},
+                 false)
+                 .token_weights(wf::TokenWeights{{WeightA, 0}, {WeightB, 100}});
+
+      if (g.choose(choices, 2, Top) != WeightA)
+      {
+        std::cout << "wf_token_weights: ceiling fallback ignored distance"
+                  << std::endl;
+        ok = false;
+      }
+    }
+
+    return ok;
+  }
+}
+
+int main()
+{
+  if (!check_wf_token_weights())
+    return 1;
+
+  std::cout << "All WF token weight tests passed" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This PR adds support for supplying token weights to the fuzzer. The weights are supplied as a map from tokens to integers and unmapped tokens defaults to 1. The driver CLI has been extended:
```bash
$ ./infix_trieste test --weights infix-int 2 infix-output 0
# prefer integers, exclude output statements
```
Note that setting a weight to zero may cause generation to abort with an exception if there is no viable option for a choice. I thought about checking for that up front (either checking for paths in the WF spec that lead to dead choices, or propagating dead choices upwards so that the path cannot happen), but I think the benefit doesn't outweigh the benefits in this case.

A possible future thing to add would be an automatic tuning of the weights based on the patterns of a pass: if the patterns have `In(Foo)` and `T(Bar)` that suggests that we should increase the weights of `Foo` and `Bar`. Preliminary experiments suggests that this reduces the number of trivial trees (trees that do not match a single rule).