### PR TITLE
Fix fast-pattern indexing for negated patterns

### DIFF
--- a/include/trieste/rewrite.h
+++ b/include/trieste/rewrite.h
@@ -1155,7 +1155,7 @@ namespace trieste
 
       Pattern operator!() const
       {
-        return {intrusive_ptr<Not>::make(pattern), FastPattern::match_pred()};
+        return {intrusive_ptr<Not>::make(pattern), FastPattern::match_any()};
       }
 
       Pattern operator*(Pattern rhs) const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,14 @@ target_link_libraries(trieste_roundtrip_test trieste::trieste)
 
 add_test(NAME trieste_roundtrip_test COMMAND trieste_roundtrip_test WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_roundtrip_test>)
 
+add_executable(trieste_rewrite_test
+  rewrite_test.cc
+)
+enable_warnings(trieste_rewrite_test)
+target_link_libraries(trieste_rewrite_test trieste::trieste)
+
+add_test(NAME trieste_rewrite_test COMMAND trieste_rewrite_test WORKING_DIRECTORY $<TARGET_FILE_DIR:trieste_rewrite_test>)
+
 if(TRIESTE_BUILD_REGEX_BENCHMARK)
   include(FetchContent)
 

--- a/test/rewrite_test.cc
+++ b/test/rewrite_test.cc
@@ -1,0 +1,45 @@
+// Copyright Microsoft and Project Verona Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+#include <trieste/trieste.h>
+
+using namespace trieste;
+
+namespace
+{
+  inline const auto Root = TokenDef("rewrite_test.Root");
+  inline const auto A = TokenDef("rewrite_test.A");
+  inline const auto B = TokenDef("rewrite_test.B");
+  inline const auto C = TokenDef("rewrite_test.C");
+  inline const auto Matched = TokenDef("rewrite_test.Matched");
+
+  bool test_not_sequence()
+  {
+    PassDef pass{
+      "not-sequence",
+      wf::empty,
+      dir::once,
+      {(!T(A) * T(B)) >> [](Match&) -> Node { return Matched; }}};
+
+    Node root = Root << C << B;
+    const auto [result, iterations, changes] = pass.run(root);
+
+    if (
+      (iterations != 1) || (changes != 1) || (result->size() != 1) ||
+      (result->front()->type() != Matched))
+    {
+      std::cerr << "A sequence beginning with !Pattern was not rewritten:"
+                << std::endl
+                << result << std::endl;
+      return false;
+    }
+
+    return true;
+  }
+}
+
+int main()
+{
+  return test_not_sequence() ? 0 : 1;
+}


### PR DESCRIPTION
The pattern `!Pat`, ensures the current cursor does not match `Pat`, and then skips forward one token.  This is different to `--Pat`, which doesn't advance the cursor.

This fixes the FastPattern for !Pat, which treated it as `--Pat`.  We consider `!Pat` to consume an arbitrary first token.